### PR TITLE
Set background color of event to grey, if event is not committed

### DIFF
--- a/src/components/Booking/BookingOverviewCalendar.vue
+++ b/src/components/Booking/BookingOverviewCalendar.vue
@@ -195,7 +195,7 @@ export default {
               name: this.getBookingTitle(booking),
               start: start,
               end: end,
-              color: booking.color,
+              color: booking.isCommitted ? booking.color : "grey",
               timed: true,
             };
           }) || []


### PR DESCRIPTION
This pull request includes a small change to the `BookingOverviewCalendar.vue` file. The change modifies the color assignment for bookings based on their commitment status.

* [`src/components/Booking/BookingOverviewCalendar.vue`](diffhunk://#diff-86e87210ccdb7b20505455c9f12f433daba303c70d8c578925f4ce8d4eb97bd5L198-R198): Updated the `color` property to assign a grey color if the booking is not committed.