### PR TITLE
Added required option for company field

### DIFF
--- a/src/views/Bookables/EditBookable.vue
+++ b/src/views/Bookables/EditBookable.vue
@@ -550,6 +550,14 @@
       <v-col class="col-auto">
         <v-switch
           dense
+          label="Firma erforderlich"
+          hide-details
+          v-model="companyRequired"
+        ></v-switch>
+      </v-col>
+      <v-col class="col-auto">
+        <v-switch
+          dense
           label="Kommentarfeld erforderlich"
           hide-details
           v-model="commentRequired"
@@ -1241,6 +1249,37 @@ export default {
             value: (
               this.$store.state.bookables.form.requiredFields || []
             ).filter((f) => f !== "comment"),
+          });
+        }
+      },
+    },
+    companyRequired: {
+      get() {
+        return this.$store.state.bookables.form.requiredFields?.includes(
+          "company"
+        );
+      },
+      set(value) {
+        if (value) {
+          if (
+            !this.$store.state.bookables.form.requiredFields?.includes(
+              "company"
+            )
+          ) {
+            this.updateValue({
+              field: "requiredFields",
+              value: [
+                ...(this.$store.state.bookables.form.requiredFields || []),
+                "company",
+              ],
+            });
+          }
+        } else {
+          this.updateValue({
+            field: "requiredFields",
+            value: (
+              this.$store.state.bookables.form.requiredFields || []
+            ).filter((f) => f !== "company"),
           });
         }
       },

--- a/src/views/BundleCheckout/CheckoutContactDetails.vue
+++ b/src/views/BundleCheckout/CheckoutContactDetails.vue
@@ -69,8 +69,9 @@
             hide-details
             dense
             filled
-            label="Firma"
+            :label="companyLabel"
             v-model="contactDetails.company"
+            :rules="companyRequired ? validationRules.required : []"
           ></v-text-field>
         </v-col>
       </v-row>
@@ -268,10 +269,16 @@ export default {
     commentRequired() {
       return this.leadItem.bookable.requiredFields?.includes("comment");
     },
+    companyRequired() {
+      return this.leadItem.bookable.requiredFields?.includes("company");
+    },
     commentLabel() {
       return this.commentRequired
         ? "Hinweise zur Buchung*"
         : "Hinweise zur Buchung";
+    },
+    companyLabel() {
+      return this.companyRequired ? "Firma*" : "Firma";
     },
     isRestrictedBookable() {
       return (


### PR DESCRIPTION
This pull request includes changes to the `EditBookable.vue` and `CheckoutContactDetails.vue` files to add a new feature that allows users to mark the "company" field as required. The most important changes include adding a new switch for the "company required" option in the `EditBookable.vue` file and updating the `CheckoutContactDetails.vue` file to conditionally display the "company" field label and validation rules based on this new setting.

Changes in `EditBookable.vue`:

* Added a new switch to mark the "company" field as required.
* Added a computed property `companyRequired` to manage the state of the "company" field requirement.

Changes in `CheckoutContactDetails.vue`:

* Updated the "company" field label to display an asterisk if the field is required.
* Added a computed property `companyRequired` to check if the "company" field is required.