### PR TITLE
BOOK-57 booking rejections by user

### DIFF
--- a/src/components/Booking/BookingRejectConformationDialog.vue
+++ b/src/components/Booking/BookingRejectConformationDialog.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-dialog v-model="openDialog" persistent max-width="800px">
+    <v-card color="accent">
+      <v-card-title>
+        <v-icon class="mr-2" color="error">mdi-alert</v-icon>
+        <span class="text-h5">Buchung stornieren</span>
+      </v-card-title>
+      <v-card-text>
+        <span class="text-h6">
+          Sind Sie sicher, dass Sie die Buchung
+          <strong>{{ toReject.id }}</strong> stornieren wollen?
+        </span>
+      </v-card-text>
+      <v-card-text>
+        <v-textarea
+          outlined
+          v-model="rejectReason"
+          label="Begründung der Stornierung"
+          placeholder="Aus welchem Grund wird die Stornierung durchgeführt?"
+          rows="2"
+        ></v-textarea>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-col class="shrink">
+          <v-btn color="primary" :loading="inProgress" @click="onReject"
+            >Ja</v-btn
+          >
+        </v-col>
+        <v-col class="shrink">
+          <v-btn outlined @click="closeDialog">Nein</v-btn>
+        </v-col>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import ApiBookingService from "@/services/api/ApiBookingService";
+import { mapGetters } from "vuex";
+
+export default {
+  name: "BookingDeleteConformationDialog",
+  props: {
+    open: {
+      type: Boolean,
+      required: true,
+    },
+    toReject: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      inProgress: false,
+      rejectReason: null,
+    };
+  },
+  computed: {
+    ...mapGetters({
+      tenant: "tenants/tenant",
+    }),
+    openDialog: {
+      get() {
+        return this.open;
+      },
+    },
+  },
+  methods: {
+    closeDialog() {
+      this.$emit("close");
+    },
+    async onReject() {
+      this.inProgress = true;
+      await ApiBookingService.rejectBooking(
+        this.toReject.id,
+        this.tenant.id,
+        this.rejectReason
+      );
+      this.inProgress = false;
+      this.closeDialog();
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -447,7 +447,27 @@ const routes = [
       requiresAuth: false,
     },
     props: true,
-  }
+  },
+  {
+    path: "/booking/request-reject/:tenantId",
+    name: "booking-request-reject",
+    component: lazyLoad("RequestRejectBooking"),
+    meta: {
+      title: "Buchung stornieren",
+      requiresAuth: false,
+    },
+    props: true,
+  },
+  {
+    path: "/booking/verify-reject/:tenantId",
+    name: "booking-request-reject",
+    component: lazyLoad("VerifyRejectBooking"),
+    meta: {
+      title: "Stornierung bestätigen",
+      requiresAuth: false,
+    },
+    props: true,
+  },
 ];
 
 const router = new VueRouter({

--- a/src/services/api/ApiBookingService.js
+++ b/src/services/api/ApiBookingService.js
@@ -71,13 +71,31 @@ export default {
       }
     );
   },
-  rejectBooking(id) {
-    return ApiClient.get(
-      `api/${store.getters["tenants/tenant"].id}/bookings/${id}/reject`,
+  rejectBooking(id, tenantId, reason) {
+    const t = tenantId || store.getters["tenants/tenant"].id;
+    return ApiClient.post(
+      `api/${t}/bookings/${id}/reject`,
+      { reason: reason },
       {
         withCredentials: true,
       }
     );
+  },
+  requestRejectBooking(id, tenantId, reason) {
+    const t = tenantId || store.getters["tenants/tenant"].id;
+    return ApiClient.post(
+      `api/${t}/bookings/${id}/request-reject`,
+      { reason: reason },
+      {
+        withCredentials: true,
+      }
+    );
+  },
+  releaseBookingHook(id, tenantId, hookId) {
+    const t = tenantId || store.getters["tenants/tenant"].id;
+    return ApiClient.get(`api/${t}/bookings/${id}/hooks/${hookId}/release`, {
+      withCredentials: true,
+    });
   },
   deleteBooking(booking) {
     return ApiClient.delete(

--- a/src/services/api/ApiBookingService.js
+++ b/src/services/api/ApiBookingService.js
@@ -131,4 +131,15 @@ export default {
       withCredentials: true,
     });
   },
+  verifyBookingOwnership(tenantId, bookingId, bookingName) {
+    return ApiClient.get(
+      `api/${tenantId}/bookings/${bookingId}/verify-ownership`,
+      {
+        params: {
+          name: bookingName,
+        },
+        withCredentials: true,
+      }
+    );
+  },
 };

--- a/src/views/Management/Bookings.vue
+++ b/src/views/Management/Bookings.vue
@@ -40,7 +40,7 @@
               @open-edit-booking="onOpenEditBooking"
               @commit-booking="commitBooking"
               @open-delete-dialog="onOpenDeleteDialog"
-              @reject-booking="rejectBooking"
+              @reject-booking="onOpenRejectDialog"
             />
           </v-skeleton-loader>
         </div>
@@ -53,7 +53,7 @@
             @open-booking="onOpenBooking"
             @open-edit-booking="onOpenEditBooking"
             @commit-booking="commitBooking"
-            @reject-booking="rejectBooking"
+            @reject-booking="onOpenRejectDialog"
             @open-delete-dialog="onOpenDeleteDialog"
           ></BookingOverviewCalendar>
         </div>
@@ -82,6 +82,11 @@
       :open="openDeleteDialog"
       @close="onCloseDeleteDialog"
     />
+    <BookingRejectConformationDialog
+      :to-reject="selectedBooking"
+      :open="openRejectDialog"
+      @close="onCloseRejectDialog"
+    />
     <v-dialog v-model="openBookingDialog" max-width="800px">
       <BookingDetails
         :booking="selectedBooking"
@@ -99,6 +104,7 @@ import { mapActions, mapGetters } from "vuex";
 import ApiBookingService from "@/services/api/ApiBookingService";
 import BookingEdit from "@/components/Booking/BookingEdit";
 import BookingDeleteConformationDialog from "@/components/Booking/BookingDeleteConformationDialog";
+import BookingRejectConformationDialog from "@/components/Booking/BookingRejectConformationDialog";
 import ApiBookablesService from "@/services/api/ApiBookablesService";
 import BookingPermissionService from "@/services/permissions/BookingPermissionService";
 import BookingDetails from "@/components/Booking/BookingDetails.vue";
@@ -111,6 +117,7 @@ export default {
     BookingOverviewCalendar,
     BookingDetails,
     BookingDeleteConformationDialog,
+    BookingRejectConformationDialog,
     AdminLayout,
     BookingEdit,
   },
@@ -142,6 +149,7 @@ export default {
       ],
       openEditDialog: false,
       openDeleteDialog: false,
+      openRejectDialog: false,
       selectedBooking: {},
       bookables: [],
       openBookingDialog: false,
@@ -262,7 +270,7 @@ export default {
         });
     },
     rejectBooking(id) {
-      ApiBookingService.rejectBooking(id)
+      ApiBookingService.rejectBooking(id, this.tenant.id)
         .then((response) => {
           if (response.status === 200) {
             this.fetchBookings();
@@ -293,6 +301,13 @@ export default {
       );
       this.openDeleteDialog = true;
     },
+    onOpenRejectDialog(bookingId) {
+      this.selectedBooking = Object.assign(
+        {},
+        this.api.bookings.find((booking) => booking.id === bookingId)
+      );
+      this.openRejectDialog = true;
+    },
     onCloseEditDialog() {
       this.fetchBookings();
       this.openEditDialog = false;
@@ -300,6 +315,10 @@ export default {
     onCloseDeleteDialog() {
       this.fetchBookings();
       this.openDeleteDialog = false;
+    },
+    onCloseRejectDialog() {
+      this.fetchBookings();
+      this.openRejectDialog = false;
     },
     onCloseBookingDialog() {
       this.openBookingDialog = false;

--- a/src/views/RequestRejectBooking.vue
+++ b/src/views/RequestRejectBooking.vue
@@ -120,20 +120,13 @@ export default {
     async sendRejectRequest() {
       try {
         this.fetching = true;
-        const bookingResponse = await ApiBookingService.getBooking(
+        const bookingResponse = await ApiBookingService.verifyBookingOwnership(
+          this.tenantId,
           this.bookingNumber,
-          this.tenantId
+          this.verificationName
         );
 
-        const booking = bookingResponse.data;
-
-        if (
-          !this.verificationName ||
-          booking.name.trim().toLowerCase() !==
-            this.verificationName.trim().toLowerCase()
-        ) {
-          this.showVerificationError = true;
-        } else {
+        if (bookingResponse.status === 200) {
           this.showVerificationError = false;
           const rejectResponse = await ApiBookingService.requestRejectBooking(
             this.bookingNumber,
@@ -146,7 +139,7 @@ export default {
           }
         }
       } catch (error) {
-        console.error(error);
+        this.showVerificationError = true;
       } finally {
         this.fetching = false;
       }

--- a/src/views/RequestRejectBooking.vue
+++ b/src/views/RequestRejectBooking.vue
@@ -1,0 +1,159 @@
+<template>
+  <v-container
+    style="
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    "
+  >
+    <div v-if="bookingNumber">
+      <v-card
+        class="pa-4 rounded-sm"
+        style="
+          overflow: hidden;
+          width: 100%;
+          min-width: 350px;
+          max-width: 500px;
+        "
+        v-if="!rejectSuccess"
+      >
+        <v-card-text class="text-center custom-card">
+          <v-alert
+            v-if="showVerificationError"
+            type="warning"
+            class="mb-10"
+            dense
+          >
+            Die eingegebene Name entspricht nicht der Buchung.
+          </v-alert>
+
+          <v-img
+            src="@/assets/app-logo.png"
+            max-width="150"
+            class="mb-4 mx-auto"
+          />
+
+          <p>
+            <strong
+              >Möchten Sie die Buchung #{{ bookingNumber }} wirklich
+              stornieren?</strong
+            >
+          </p>
+
+          <v-text-field
+            outlined
+            v-model="verificationName"
+            label="Ihr Name (wie in der Buchung)"
+            hint="Bitte geben Sie Ihren Namen ein, so wie er auch in der Buchung hinterlegt wurde."
+            persistent-hint
+          ></v-text-field>
+          <v-textarea
+            outlined
+            v-model="rejectReason"
+            rows="3"
+            label="Hinweis zur Stornierung (optional)"
+            class="mt-3"
+          ></v-textarea>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn
+            :loading="fetching"
+            block
+            color="primary"
+            @click="sendRejectRequest"
+          >
+            Buchung jetzt stornieren</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+
+      <v-card
+        class="pa-4 rounded-sm"
+        style="
+          overflow: hidden;
+          width: 100%;
+          min-width: 350px;
+          max-width: 500px;
+        "
+        v-else
+      >
+        <v-card-text class="text-center">
+          <v-icon size="45px" color="primary">mdi-email</v-icon>
+          <p class="text-h6 font-weight-bold">Stornierung bestätigen</p>
+          <p>
+            Wir haben Ihnen eine E-Mail zur Bestätigung Ihrer Stornierung
+            gesendet. Bitte überprüfen Sie Ihr Postfach und bestätigen Sie die
+            Stornierung, um den Vorgang abzuschließen.
+          </p>
+        </v-card-text>
+      </v-card>
+    </div>
+    <div v-else>
+      <v-alert type="error" dense> Keine Buchungsnummer gefunden. </v-alert>
+    </div>
+  </v-container>
+</template>
+
+<script>
+import ApiBookingService from "@/services/api/ApiBookingService";
+
+export default {
+  name: "RequestRejectBooking",
+  props: {
+    tenantId: {
+      type: String,
+    },
+  },
+  computed: {},
+  data() {
+    return {
+      bookingNumber: this.$route.query.id,
+      verificationName: null,
+      rejectReason: null,
+      showVerificationError: false,
+      rejectSuccess: false,
+      fetching: false,
+    };
+  },
+  methods: {
+    async sendRejectRequest() {
+      try {
+        this.fetching = true;
+        const bookingResponse = await ApiBookingService.getBooking(
+          this.bookingNumber,
+          this.tenantId
+        );
+
+        const booking = bookingResponse.data;
+
+        if (
+          !this.verificationName ||
+          booking.name.trim().toLowerCase() !==
+            this.verificationName.trim().toLowerCase()
+        ) {
+          this.showVerificationError = true;
+        } else {
+          this.showVerificationError = false;
+          const rejectResponse = await ApiBookingService.requestRejectBooking(
+            this.bookingNumber,
+            this.tenantId,
+            this.rejectReason
+          );
+
+          if (rejectResponse.status === 201) {
+            this.rejectSuccess = true;
+          }
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.fetching = false;
+      }
+    },
+  },
+  async mounted() {},
+};
+</script>
+
+<style scoped></style>

--- a/src/views/VerifyRejectBooking.vue
+++ b/src/views/VerifyRejectBooking.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-container
+    style="
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    "
+  >
+    <v-card
+      class="pa-4 rounded-sm"
+      style="overflow: hidden; width: 100%; min-width: 350px; max-width: 500px"
+    >
+      <v-card-text class="text-center" v-if="fetching">
+        <v-progress-circular
+          indeterminate
+          color="primary"
+          size="64"
+        ></v-progress-circular>
+      </v-card-text>
+      <v-card-text class="text-center" v-if="!fetching && rejectSuccess">
+        <v-icon size="45px" color="success">mdi-check</v-icon>
+        <p class="text-h6 font-weight-bold">Stornierung bestätigt</p>
+        <p>
+          Ihre Stornierung wurde erfolgreich bestätigt. Sie erhalten in Kürze
+          eine Bestätigung per E-Mail.
+        </p>
+      </v-card-text>
+      <v-card-text class="text-center" v-if="!fetching && !rejectSuccess">
+        <v-icon size="45px" color="error">mdi-close</v-icon>
+        <p class="text-h6 font-weight-bold">Stornierung nicht möglich</p>
+        <p>
+          Die Stornerung konnte nicht durchgeführt werden. Bitte versuchen Sie
+          es erneut oder kontaktieren Sie Ihren Ansprechpartner.
+        </p>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import ApiBookingService from "@/services/api/ApiBookingService";
+
+export default {
+  name: "RequestRejectBooking",
+  props: {
+    tenantId: {
+      type: String,
+    },
+  },
+  computed: {},
+  data() {
+    return {
+      bookingNumber: this.$route.query.id,
+      hookId: this.$route.query.hookId,
+      rejectSuccess: false,
+      fetching: false,
+    };
+  },
+  methods: {
+    async releaseRejectHook() {
+      try {
+        this.fetching = true;
+
+        const response = await ApiBookingService.releaseBookingHook(
+          this.bookingNumber,
+          this.tenantId,
+          this.hookId
+        );
+
+        if (response.status === 200) {
+          this.rejectSuccess = true;
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.fetching = false;
+      }
+    },
+  },
+  async mounted() {
+    await this.releaseRejectHook();
+  },
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
This pull request introduces a new feature to handle booking rejections, including user confirmation and verification steps. The most important changes are the addition of new components for the rejection process, updates to the routing configuration, and modifications to the booking service to support the new functionality.

### New components for booking rejection:
* [`src/components/Booking/BookingRejectConformationDialog.vue`](diffhunk://#diff-aa461abde5bc49c149e892c49f04ef1c425dc07c5eadaaf67666e3b9ad90637cR1-R88): Added a new dialog component to confirm booking rejections and collect rejection reasons from users.
* [`src/views/RequestRejectBooking.vue`](diffhunk://#diff-0b154015047a4c65cef51dfc9a79f5542570bd8d83c4480cd2756369c9d4ba47R1-R159): Created a new view for users to request booking rejection, including verification of user identity.
* [`src/views/VerifyRejectBooking.vue`](diffhunk://#diff-3c32e2e503108ed9c109ffd8ccbdfddc4e46bcb52960b50a067290033fafebfcR1-R87): Added a new view to handle the verification of booking rejection requests.

### Routing updates:
* [`src/router/index.js`](diffhunk://#diff-3210ca9ed615e6f0fc1743fc09be3c86bc38178dcc050e5a41ff7982d15875b7L450-R470): Updated the routing configuration to include new paths for booking rejection requests and verification.

### Booking service modifications:
* [`src/services/api/ApiBookingService.js`](diffhunk://#diff-f1165adf7d5921a778ede592f8e2ed5809d1057f439882befb682bc2f388e692L74-R99): Updated the booking service to include new methods for handling booking rejection requests and verification.

### Integration in booking management:
* [`src/views/Management/Bookings.vue`](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eL43-R43): Integrated the new booking rejection dialog and updated methods to handle the new rejection process. [[1]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eL43-R43) [[2]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eL56-R56) [[3]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eR85-R89) [[4]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eR107) [[5]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eR120) [[6]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eR152) [[7]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eL265-R273) [[8]](diffhunk://#diff-d1f48fce1c79692a8c9225e692acfa934665d0fafda1eb1c75485ce88759364eR304-R310)