### PR TITLE
error when displaying the discount solved

### DIFF
--- a/src/views/BundleCheckout/CheckoutQuickSummary.vue
+++ b/src/views/BundleCheckout/CheckoutQuickSummary.vue
@@ -560,6 +560,7 @@ export default {
           off += item.regularPriceEur - item.userPriceEur;
         }
       }
+      return off;
     },
 
     totalGrossPriceOff() {


### PR DESCRIPTION
This pull request includes a minor change to the `CheckoutQuickSummary.vue` file. The change ensures that the `off` variable is returned at the end of the `totalGrossPriceOff` method, which likely fixes a missing return value issue.