### PR TITLE
Fixed a bug that prevented isLongRange from being set to false

### DIFF
--- a/src/components/Bookable/BookableTimeDependantAttributes.vue
+++ b/src/components/Bookable/BookableTimeDependantAttributes.vue
@@ -999,6 +999,7 @@ export default {
           this.isLongRange = value;
         } else {
           this.updateValue({ field: "longRangeOptions", value: null });
+          this.isLongRange = value;
         }
       },
     },
@@ -1019,6 +1020,7 @@ export default {
           this.isLongRange = value;
         } else {
           this.updateValue({ field: "longRangeOptions", value: null });
+          this.isLongRange = value;
         }
       },
     },


### PR DESCRIPTION
This pull request includes a minor update to the `src/components/Bookable/BookableTimeDependantAttributes.vue` file. The change ensures that the `isLongRange` property is consistently updated when the `longRangeOptions` field is set to `null`.

- [`src/components/Bookable/BookableTimeDependantAttributes.vue`](diffhunk://#diff-a50f93ea2e46002998c029082e9d5511ea65d871c3ab79a9fa7e0ff2e867a304R1002): Added a line to set `this.isLongRange = value` in both relevant conditional branches to maintain consistent state updates. [[1]](diffhunk://#diff-a50f93ea2e46002998c029082e9d5511ea65d871c3ab79a9fa7e0ff2e867a304R1002) [[2]](diffhunk://#diff-a50f93ea2e46002998c029082e9d5511ea65d871c3ab79a9fa7e0ff2e867a304R1023)