### PR TITLE
added theme persistance

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -310,7 +310,9 @@ export default {
         });
     },
     darkMode() {
-      this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
+      this.$store.dispatch("theme/toggleDarkMode").then(isDarkMode => {
+        this.$vuetify.theme.dark = isDarkMode;
+      });
     },
     fetchTenants() {
       ApiTenantService.getTenants(true).then((response) => {

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,7 @@ new Vue({
 
   created() {
     this.initializeApp();
+    this.initializeTheme();
   },
   mounted() {
     this.loadUsersnap();
@@ -57,6 +58,7 @@ new Vue({
     ...mapActions({
       updateUser: "user/update",
       deleteUser: "user/delete",
+      initDarkMode: "theme/initDarkMode",
     }),
     initializeApp() {
       const userName = PersistenceService.getFromLocalStorage("user");
@@ -77,6 +79,12 @@ new Vue({
       script.defer = true;
       script.src = `https://widget.usersnap.com/load/${process.env.VUE_APP_USERSNAP_API_KEY}?onload=onUsersnapLoad`;
       document.getElementsByTagName("head")[0].appendChild(script);
+    },
+    initializeTheme() {
+      // Initialize dark mode from localStorage
+      this.initDarkMode().then(isDarkMode => {
+        this.$vuetify.theme.dark = isDarkMode;
+      });
     },
   },
 }).$mount("#app");

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import bookables from "./modules/bookables";
 import loading from "./modules/loading";
 import instance from "./modules/instance";
 import authStore from "@/store/modules/authStore";
+import theme from "./modules/theme";
 
 Vue.use(Vuex);
 
@@ -21,7 +22,8 @@ export default new Vuex.Store({
     bookables,
     loading,
     instance,
-    authStore
+    authStore,
+    theme
   },
   actions: {
     reset({ dispatch }) {
@@ -33,6 +35,7 @@ export default new Vuex.Store({
       dispatch("loading/reset");
       dispatch("instance/reset");
       dispatch("authStore/reset");
+      dispatch("theme/reset");
     }
   }
 });

--- a/src/store/modules/theme.js
+++ b/src/store/modules/theme.js
@@ -1,0 +1,39 @@
+import PersistenceService from "@/services/PersistenceService";
+
+const THEME_STORAGE_KEY = "darkMode";
+
+export default {
+  namespaced: true,
+  state: {
+    isDarkMode: PersistenceService.getFromLocalStorage(THEME_STORAGE_KEY) || false
+  },
+  getters: {
+    isDarkMode: state => state.isDarkMode
+  },
+  mutations: {
+    SET_DARK_MODE(state, isDarkMode) {
+      state.isDarkMode = isDarkMode;
+    }
+  },
+  actions: {
+    toggleDarkMode({ commit, state }) {
+      const newDarkModeValue = !state.isDarkMode;
+      commit("SET_DARK_MODE", newDarkModeValue);
+      PersistenceService.writeToLocalStorage(THEME_STORAGE_KEY, newDarkModeValue);
+      return newDarkModeValue;
+    },
+    initDarkMode({ commit, state }) {
+      // This action is used to initialize the dark mode from localStorage
+      const savedDarkMode = PersistenceService.getFromLocalStorage(THEME_STORAGE_KEY);
+      if (savedDarkMode !== undefined) {
+        commit("SET_DARK_MODE", savedDarkMode);
+      }
+      return state.isDarkMode;
+    },
+    reset({ commit }) {
+      // Reset to default (light mode)
+      commit("SET_DARK_MODE", false);
+      PersistenceService.removeFromLocalStorage(THEME_STORAGE_KEY);
+    }
+  }
+};

--- a/src/views/BundleCheckout/CheckoutQuickSummary.vue
+++ b/src/views/BundleCheckout/CheckoutQuickSummary.vue
@@ -243,7 +243,7 @@
 
     <v-card
       class="mt-5 rounded-sm"
-      color="red lighten-4"
+      :color="$vuetify.theme.dark ? 'red' : 'red lighten-4'"
       outlined
       v-if="allItemsValid === false"
     >


### PR DESCRIPTION
This pull request introduces a new Vuex module to manage theme preferences, specifically dark mode, and integrates it throughout the application to improve theme persistence and initialization. The most important changes include adding the `theme` Vuex module, updating components and views to use the new dark mode state, and ensuring dark mode is initialized on app startup.

### Theme Management Enhancements:
* **New Vuex Module for Theme**: Added a `theme` Vuex module (`src/store/modules/theme.js`) to handle dark mode state, including actions for toggling, initializing, and resetting dark mode. This module uses `PersistenceService` to persist the dark mode preference in `localStorage`.
* **Vuex Store Integration**: Registered the `theme` module in the Vuex store (`src/store/index.js`) and added a `reset` method to clear theme state during app resets. [[1]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744R12) [[2]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744L24-R26) [[3]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744R38)

### Application Initialization:
* **Dark Mode Initialization**: Added an `initializeTheme` method in `src/main.js` to set the dark mode state on app startup by reading the persisted value from `localStorage`. [[1]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R52) [[2]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R83-R88)
* **Action Mapping**: Mapped the `initDarkMode` Vuex action in `src/main.js` to facilitate initialization.

### Component Updates:
* **Navbar Dark Mode Toggle**: Updated the `darkMode` method in `src/components/Navbar.vue` to use the `theme/toggleDarkMode` Vuex action, ensuring consistent state management.
* **Dynamic Theme in Views**: Modified `CheckoutQuickSummary.vue` to dynamically adjust the card color based on the current dark mode state.