### PR TITLE
added status change confirmation

### DIFF
--- a/src/components/Booking/BookingConfirmStatusChangeDialog.vue
+++ b/src/components/Booking/BookingConfirmStatusChangeDialog.vue
@@ -1,0 +1,127 @@
+<!-- BookingConfirmStatusChangeDialog.vue -->
+<template>
+  <v-dialog v-model="openDialog" persistent max-width="600px">
+    <v-card color="accent">
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-3" color="warning">mdi-alert-circle</v-icon>
+        <span class="text-h6">Status-Änderung bestätigen</span>
+      </v-card-title>
+
+      <v-card-text class="pt-4">
+        <p class="mb-3">
+          Beim Verschieben wird die Buchung automatisch in folgenden Status
+          gesetzt:
+        </p>
+
+        <v-chip
+          v-for="statusText in translatedStatusList"
+          :key="statusText"
+          class="ma-1"
+          color="primary"
+          small
+          text-color="white"
+        >
+          {{ statusText }}
+        </v-chip>
+
+        <v-divider class="my-4"></v-divider>
+        <v-checkbox
+          v-model="dontAskAgain"
+          label="Für diese Art von Status-Änderung nicht mehr fragen"
+          hide-details
+          class="mt-2"
+        ></v-checkbox>
+      </v-card-text>
+
+      <v-card-actions class="px-6 pb-4">
+        <v-spacer></v-spacer>
+        <v-btn outlined @click="closeDialog" :disabled="inProgress">
+          Abbrechen
+        </v-btn>
+        <v-btn color="primary" @click="onConfirm" :loading="inProgress">
+          Bestätigen
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { mapActions } from "vuex";
+
+export default {
+  name: "BookingConfirmStatusChangeDialog",
+  props: {
+    open: {
+      type: Boolean,
+      required: true,
+    },
+    status: {
+      type: Array,
+      required: true,
+    },
+    inProgress: {
+      type: Boolean,
+      default: false,
+    },
+    statusKey: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      dontAskAgain: false,
+    };
+  },
+  computed: {
+    openDialog: {
+      get() {
+        return this.open;
+      },
+    },
+
+    statusMap() {
+      return {
+        commit: "Freigegeben",
+        paid: "Bezahlt",
+        reject: "Abgelehnt",
+        pending: "Ausstehend",
+        cancelled: "Storniert",
+      };
+    },
+
+    translatedStatusList() {
+      return this.status.map((s) => this.statusMap[s] || s);
+    },
+  },
+  methods: {
+    ...mapActions("userPreferences", ["setSkipStatusConfirmation"]),
+
+    closeDialog() {
+      this.dontAskAgain = false;
+      this.$emit("reject");
+    },
+
+    async onConfirm() {
+      if (this.dontAskAgain) {
+        await this.setSkipStatusConfirmation({
+          statusKey: this.statusKey,
+          skip: true,
+        });
+      }
+
+      this.dontAskAgain = false;
+      this.$emit("confirm");
+    },
+  },
+
+  watch: {
+    open(newVal) {
+      if (!newVal) {
+        this.dontAskAgain = false;
+      }
+    },
+  },
+};
+</script>

--- a/src/components/Booking/BookingKanban.vue
+++ b/src/components/Booking/BookingKanban.vue
@@ -55,16 +55,28 @@
         @move-task="moveTask"
       />
     </div>
+
+    <BookingConfirmStatusChangeDialog
+      v-if="confirmStatusChange"
+      :open="confirmStatusChange"
+      :status="onChangeBookingStatus"
+      :status-key="currentStatusKey"
+      @reject="statusChangeRejected"
+      @confirm="statusChangeConfirmed"
+      :in-progress="isLoading"
+    />
   </div>
 </template>
 
 <script>
 import ApiWorkflowService from "@/services/api/ApiWorkflowService";
 import BookingKanbanColumn from "@/components/Booking/KanbanColumn.vue";
+import BookingConfirmStatusChangeDialog from "@/components/Booking/BookingConfirmStatusChangeDialog.vue";
+import { mapActions, mapGetters } from "vuex";
 
 export default {
   name: "BookingWorkflow",
-  components: { BookingKanbanColumn },
+  components: { BookingConfirmStatusChangeDialog, BookingKanbanColumn },
   props: {
     bookings: {
       type: Array,
@@ -90,14 +102,22 @@ export default {
       dragging: false,
       showScrollLeft: false,
       showScrollRight: false,
+      confirmStatusChange: false,
+      onChangeBookingStatus: [],
+      newStatusId: null,
+      oldStatusId: null,
+      temporaryEvent: null,
+      currentStatusKey: null,
     };
   },
   computed: {
+    ...mapGetters("userPreferences", ["shouldSkipStatusConfirmation"]),
     isLoading() {
       return this.loading || this.internalLoading;
     },
   },
   methods: {
+    ...mapActions("userPreferences", ["loadSkipStatusConfirmations"]),
     combineWorkflow() {
       this.combinedWorkflow = this.workflow.states.map((state) => {
         const filteredTasks = state.tasks
@@ -149,7 +169,7 @@ export default {
           newIndex: evt.added.newIndex,
         });
         this.backlog = await ApiWorkflowService.getBacklog();
-        this.$emit("update:booking", evt.added.element.id)
+        this.$emit("update:booking", evt.added.element.id);
       }
       if (evt.moved) {
         this.workflow = await ApiWorkflowService.updateTask({
@@ -159,7 +179,7 @@ export default {
           newIndex: evt.moved.newIndex,
         });
         this.backlog = await ApiWorkflowService.getBacklog();
-        this.$emit("update:booking", evt.added.element.id)
+        this.$emit("update:booking", evt.added.element.id);
       }
     },
     archiveTask: async function (taskId) {
@@ -214,7 +234,7 @@ export default {
     scrollLeft() {
       const container = this.$refs.kanbanContainer;
       container.scrollBy({
-        left: -200, // Anzahl Pixel die gescrollt werden soll
+        left: -200,
         behavior: "smooth",
       });
     },
@@ -242,7 +262,92 @@ export default {
       }
     },
     handleChangeTask(evt, statusId) {
-      this.moveTask(evt, statusId);
+      if (!evt.added) {
+        this.moveTask(evt, statusId);
+        return;
+      }
+
+      const taskId = evt.added.element.id;
+      const oldStatus = this.findTaskCurrentStatus(taskId);
+      const newStatus = this.workflow.states.find(
+        (state) => state.id === statusId
+      );
+
+      const statusChangeActions =
+        newStatus.actions?.filter(
+          (action) => action.type === "bookingStatus"
+        ) || [];
+
+      if (statusChangeActions.length > 0) {
+        const statusKey = this.generateStatusKey(
+          oldStatus.id,
+          statusId,
+          statusChangeActions
+        );
+
+        if (this.shouldSkipStatusConfirmation(statusKey)) {
+          this.moveTask(evt, statusId);
+        } else {
+          this.showStatusChangeConfirmation(
+            evt,
+            statusId,
+            oldStatus.id,
+            statusChangeActions,
+            statusKey
+          );
+        }
+      } else {
+        this.moveTask(evt, statusId);
+      }
+    },
+
+    generateStatusKey(fromStatus, toStatus, actions) {
+      const actionTypes = actions
+        .map((action) => action.bookingStatus)
+        .flat()
+        .sort()
+        .join("_");
+
+      return `${fromStatus}_to_${toStatus}_${actionTypes}`;
+    },
+
+    findTaskCurrentStatus(taskId) {
+      return this.workflow.states.find((state) =>
+        state.tasks.some((task) => task.id === taskId)
+      );
+    },
+
+    showStatusChangeConfirmation(evt, newStatusId, oldStatusId, actions, statusKey) {
+      this.onChangeBookingStatus = actions
+        .map(action => action.bookingStatus)
+        .flat();
+
+      this.newStatusId = newStatusId;
+      this.oldStatusId = oldStatusId;
+      this.temporaryEvent = evt;
+      this.currentStatusKey = statusKey;
+      this.confirmStatusChange = true;
+    },
+
+    statusChangeConfirmed() {
+      this.executeStatusChange(this.newStatusId);
+    },
+
+    statusChangeRejected() {
+      this.executeStatusChange(this.oldStatusId);
+    },
+
+    executeStatusChange(statusId) {
+      this.moveTask(this.temporaryEvent, statusId);
+      this.resetStatusChangeState();
+    },
+
+    resetStatusChangeState() {
+      this.onChangeBookingStatus = [];
+      this.temporaryEvent = null;
+      this.newStatusId = null;
+      this.oldStatusId = null;
+      this.confirmStatusChange = false;
     },
   },
   watch: {
@@ -273,6 +378,7 @@ export default {
     },
   },
   async mounted() {
+    await this.loadSkipStatusConfirmations();
     this.workflow = await ApiWorkflowService.getWorkflowStates();
     this.backlog = await ApiWorkflowService.getBacklog();
 

--- a/src/components/Booking/BookingKanban.vue
+++ b/src/components/Booking/BookingKanban.vue
@@ -179,7 +179,7 @@ export default {
           newIndex: evt.moved.newIndex,
         });
         this.backlog = await ApiWorkflowService.getBacklog();
-        this.$emit("update:booking", evt.added.element.id);
+        this.$emit("update:booking", evt.moved.element.id);
       }
     },
     archiveTask: async function (taskId) {

--- a/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
+++ b/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
@@ -165,7 +165,7 @@
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn outlined @click="closeDialog">Abbrechen</v-btn>
-        <v-btn color="primary" @click="saveWorkflowStatus">Speichern</v-btn>
+        <v-btn color="primary" @click="saveWorkflowStatus">Übernehmen</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,6 +10,7 @@ import loading from "./modules/loading";
 import instance from "./modules/instance";
 import authStore from "@/store/modules/authStore";
 import theme from "./modules/theme";
+import userPreferences from "./modules/userPreferences";
 
 Vue.use(Vuex);
 
@@ -23,7 +24,8 @@ export default new Vuex.Store({
     loading,
     instance,
     authStore,
-    theme
+    theme,
+    userPreferences
   },
   actions: {
     reset({ dispatch }) {

--- a/src/store/modules/userPreferences.js
+++ b/src/store/modules/userPreferences.js
@@ -1,0 +1,47 @@
+const state = {
+  skipStatusChangeConfirmations: {},
+};
+
+const mutations = {
+  SET_SKIP_STATUS_CONFIRMATION(state, { statusKey, skip }) {
+    state.skipStatusChangeConfirmations = {
+      ...state.skipStatusChangeConfirmations,
+      [statusKey]: skip,
+    };
+  },
+};
+
+const actions = {
+  setSkipStatusConfirmation({ commit }, { statusKey, skip }) {
+    commit("SET_SKIP_STATUS_CONFIRMATION", { statusKey, skip });
+
+    localStorage.setItem(
+      "skipStatusChangeConfirmations",
+      JSON.stringify(state.skipStatusChangeConfirmations)
+    );
+  },
+
+  loadSkipStatusConfirmations({ commit }) {
+    const saved = localStorage.getItem("skipStatusChangeConfirmations");
+    if (saved) {
+      const preferences = JSON.parse(saved);
+      Object.entries(preferences).forEach(([statusKey, skip]) => {
+        commit("SET_SKIP_STATUS_CONFIRMATION", { statusKey, skip });
+      });
+    }
+  },
+};
+
+const getters = {
+  shouldSkipStatusConfirmation: (state) => (statusKey) => {
+    return state.skipStatusChangeConfirmations[statusKey] || false;
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters,
+};

--- a/src/store/modules/userPreferences.js
+++ b/src/store/modules/userPreferences.js
@@ -24,10 +24,14 @@ const actions = {
   loadSkipStatusConfirmations({ commit }) {
     const saved = localStorage.getItem("skipStatusChangeConfirmations");
     if (saved) {
-      const preferences = JSON.parse(saved);
-      Object.entries(preferences).forEach(([statusKey, skip]) => {
-        commit("SET_SKIP_STATUS_CONFIRMATION", { statusKey, skip });
-      });
+      try {
+        const preferences = JSON.parse(saved);
+        Object.entries(preferences).forEach(([statusKey, skip]) => {
+          commit("SET_SKIP_STATUS_CONFIRMATION", { statusKey, skip });
+        });
+      } catch (error) {
+        console.error("Failed to parse skipStatusChangeConfirmations from localStorage:", error);
+      }
     }
   },
 };


### PR DESCRIPTION
This pull request introduces a new feature to confirm booking status changes with a dialog and adds user preferences for skipping such confirmations. It also includes minor refactoring and UI text updates. Below is a summary of the most important changes:

### New Feature: Booking Status Change Confirmation

* Added a new `BookingConfirmStatusChangeDialog` component to display a confirmation dialog when booking statuses are changed. The dialog includes a checkbox to skip future confirmations for similar changes. (`src/components/Booking/BookingConfirmStatusChangeDialog.vue`)
* Integrated the new dialog into the `BookingKanban` component to handle status change confirmations. This includes logic to determine when to show the dialog and actions to confirm or reject changes. (`src/components/Booking/BookingKanban.vue`) [[1]](diffhunk://#diff-b23b0748d20465bcef0f847c131fe442f9f3a1db727ef15e160c5a38b9981d14R58-R79) [[2]](diffhunk://#diff-b23b0748d20465bcef0f847c131fe442f9f3a1db727ef15e160c5a38b9981d14R265-R350)

### State Management: User Preferences for Status Change Confirmation

* Added a new `userPreferences` Vuex module to manage preferences for skipping status change confirmations. Preferences are stored in `localStorage` and loaded on initialization. (`src/store/modules/userPreferences.js`)
* Updated the Vuex store to include the `userPreferences` module. (`src/store/index.js`) [[1]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744R13) [[2]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744L26-R28)

### Minor Changes and Refactoring

* Fixed a missing semicolon in the `BookingKanban` component's `export default` object. (`src/components/Booking/BookingKanban.vue`) [[1]](diffhunk://#diff-b23b0748d20465bcef0f847c131fe442f9f3a1db727ef15e160c5a38b9981d14L152-R172) [[2]](diffhunk://#diff-b23b0748d20465bcef0f847c131fe442f9f3a1db727ef15e160c5a38b9981d14L162-R182)
* Removed unnecessary comments and improved code readability in `BookingKanban.vue`. (`src/components/Booking/BookingKanban.vue`)

### UI Text Update

* Updated the button text in the `TenantEditWorkflowStatusDialog` component from "Speichern" to "Übernehmen" for better clarity. (`src/components/Tenant/TenantEditWorkflowStatusDialog.vue`)