### PR TITLE
added notifications

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -31,6 +31,7 @@
         </template>
         <span>Theme wechseln</span>
       </v-tooltip>
+      <NotificationDisplay class="mr-2" />
       <v-menu offset-y>
         <template v-slot:activator="{ on: menu, attrs }">
           <v-tooltip bottom>
@@ -145,6 +146,7 @@ import { mapActions, mapGetters } from "vuex";
 import ToastService from "@/services/ToastService";
 import ApiAuthService from "@/services/api/ApiAuthService";
 import ApiTenantService from "@/services/api/ApiTenantService";
+import NotificationDisplay from "@/components/NotificationDisplay";
 
 export default {
   data: () => ({
@@ -288,7 +290,9 @@ export default {
     //currentTenant: "",
     tenants: [],
   }),
-  components: {},
+  components: {
+    NotificationDisplay,
+  },
   methods: {
     ...mapActions({
       addToast: "toasts/add",

--- a/src/components/NotificationDisplay.vue
+++ b/src/components/NotificationDisplay.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="notification-container">
+    <v-dialog v-model="sequentialDialog" max-width="750">
+      <v-card v-if="filteredNotifications.length > 0">
+        <v-card-title class="headline">
+          <span  v-if="filteredNotifications.length > 1" class="ml-4"> Benachrichtigung {{ currentNotificationIndex + 1 }} von {{ filteredNotifications.length }}</span>
+          <v-spacer></v-spacer>
+          <v-btn icon @click="sequentialDialog = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text>
+          <div v-if="filteredNotifications[currentNotificationIndex]" v-html="filteredNotifications[currentNotificationIndex].message"></div>
+        </v-card-text>
+        <v-card-actions v-if="filteredNotifications.length > 1">
+          <v-btn text :disabled="currentNotificationIndex === 0" @click="previousNotification">
+            <v-icon>mdi-chevron-left</v-icon> Previous
+          </v-btn>
+          <v-spacer></v-spacer>
+          <v-btn text :disabled="currentNotificationIndex >= filteredNotifications.length - 1" @click="nextNotification">
+            Next <v-icon>mdi-chevron-right</v-icon>
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+
+export default {
+  name: "NotificationDisplay",
+  data() {
+    return {
+      dialog: false,
+      currentNotificationIndex: 0,
+      sequentialDialog: false,
+    };
+  },
+  mounted() {
+    this.$nextTick(() => {
+      if (this.unviewedNotifications.length > 0) {
+        this.currentNotificationIndex = 0;
+        this.showSequentialNotification();
+      }
+    });
+  },
+  methods: {
+    ...mapActions({
+      markAsViewed: "viewedNotifications/markAsViewed",
+    }),
+    markNotificationsAsViewed() {
+      this.filteredNotifications.forEach(notification => {
+        if (notification.id) {
+          this.markAsViewed(notification.id);
+        }
+      });
+    },
+    markCurrentNotificationAsViewed() {
+      const notification = this.filteredNotifications[this.currentNotificationIndex];
+      if (notification && notification.id) {
+        this.markAsViewed(notification.id);
+      }
+    },
+    showSequentialNotification() {
+      this.sequentialDialog = true;
+      this.markCurrentNotificationAsViewed();
+    },
+    nextNotification() {
+      if (this.currentNotificationIndex < this.filteredNotifications.length - 1) {
+        this.currentNotificationIndex++;
+        this.markCurrentNotificationAsViewed();
+      } else {
+        this.sequentialDialog = false;
+      }
+    },
+    previousNotification() {
+      if (this.currentNotificationIndex > 0) {
+        this.currentNotificationIndex--;
+        this.markCurrentNotificationAsViewed();
+      }
+    },
+  },
+  computed: {
+    ...mapGetters({
+      instance: "instance/instance",
+      currentTenantId: "tenants/currentTenantId",
+      isNotificationViewed: "viewedNotifications/isViewed",
+    }),
+
+    userNotifications() {
+      return this.instance?.userNotifications || [];
+    },
+
+    filteredNotifications() {
+      return this.userNotifications.filter((notification) => {
+        if (notification.tenants && notification.tenants.length > 0) {
+          if (
+            !this.currentTenantId ||
+            !notification.tenants.includes(this.currentTenantId)
+          ) {
+            return false;
+          }
+        }
+
+        if (notification.path && notification.path.length > 0) {
+          const currentPath = this.$route.name;
+          if (!notification.path.includes(currentPath)) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    },
+
+    unviewedNotifications() {
+      return this.filteredNotifications.filter(notification =>
+        !notification.id || !this.isNotificationViewed(notification.id)
+      );
+    },
+  },
+};
+</script>
+
+<style scoped>
+.notification-container {
+  margin-bottom: 16px;
+}
+</style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import bookables from "./modules/bookables";
 import loading from "./modules/loading";
 import instance from "./modules/instance";
 import authStore from "@/store/modules/authStore";
+import viewedNotifications from "./modules/viewedNotifications";
 
 Vue.use(Vuex);
 
@@ -21,7 +22,8 @@ export default new Vuex.Store({
     bookables,
     loading,
     instance,
-    authStore
+    authStore,
+    viewedNotifications
   },
   actions: {
     reset({ dispatch }) {
@@ -33,6 +35,7 @@ export default new Vuex.Store({
       dispatch("loading/reset");
       dispatch("instance/reset");
       dispatch("authStore/reset");
+      dispatch("viewedNotifications/reset");
     }
   }
 });

--- a/src/store/modules/viewedNotifications.js
+++ b/src/store/modules/viewedNotifications.js
@@ -1,0 +1,44 @@
+import PersistenceService from "@/services/PersistenceService";
+
+const namespaced = true;
+
+const state = {
+  viewedIds: PersistenceService.getFromLocalStorage("viewedNotifications") || [],
+};
+
+const mutations = {
+  ADD_VIEWED_NOTIFICATION(state, notificationId) {
+    if (!state.viewedIds.includes(notificationId)) {
+      state.viewedIds.push(notificationId);
+      PersistenceService.writeToLocalStorage("viewedNotifications", state.viewedIds);
+    }
+  },
+  RESET(state) {
+    state.viewedIds = [];
+    PersistenceService.removeFromLocalStorage("viewedNotifications");
+  },
+};
+
+const actions = {
+  markAsViewed({ commit }, notificationId) {
+    commit("ADD_VIEWED_NOTIFICATION", notificationId);
+  },
+  reset({ commit }) {
+    commit("RESET");
+  }
+};
+
+const getters = {
+  isViewed: (state) => (notificationId) => {
+    return state.viewedIds.includes(notificationId);
+  },
+  viewedIds: (state) => state.viewedIds,
+};
+
+export default {
+  state,
+  mutations,
+  actions,
+  getters,
+  namespaced,
+};


### PR DESCRIPTION
This pull request introduces a new notification system to the application, allowing users to view and manage notifications through a `NotificationDisplay` component. It also adds Vuex state management for tracking viewed notifications. Below are the key changes grouped by theme:

### Notification Component Integration

* Added a new `NotificationDisplay` component to display user notifications in a sequential dialog with navigation controls. The component includes logic for filtering notifications based on tenant and route, and marking them as viewed. (`src/components/NotificationDisplay.vue`)
* Integrated the `NotificationDisplay` component into the `Navbar` by importing it, registering it in the `components` object, and adding it to the template. (`src/components/Navbar.vue`) [[1]](diffhunk://#diff-4d808a77b3b0f796522e9ab983d06bfd86ebbf70163d0ba808154780aea295f0R34) [[2]](diffhunk://#diff-4d808a77b3b0f796522e9ab983d06bfd86ebbf70163d0ba808154780aea295f0R149) [[3]](diffhunk://#diff-4d808a77b3b0f796522e9ab983d06bfd86ebbf70163d0ba808154780aea295f0L291-R295)

### Vuex State Management for Notifications

* Added a new Vuex module, `viewedNotifications`, to manage the state of viewed notifications. This includes storing viewed notification IDs in local storage and providing actions, mutations, and getters for marking notifications as viewed and resetting the state. (`src/store/modules/viewedNotifications.js`)
* Registered the `viewedNotifications` module in the Vuex store and updated the global reset action to include resetting this module. (`src/store/index.js`) [[1]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744R12) [[2]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744L24-R26) [[3]](diffhunk://#diff-68cfdabf9fa2ce99fa19fdbe25785f2622056c22f88b1f846d3ac7ffffea0744R38)