### PR TITLE
only display tenant roles

### DIFF
--- a/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
+++ b/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
@@ -231,7 +231,7 @@ export default {
 
   methods: {
     async fetchRoles() {
-      await ApiRolesService.getRoles().then((result) => {
+      await ApiRolesService.getTenantRoles(true).then((result) => {
         this.availableRoles = result?.data;
       });
     },

--- a/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
+++ b/src/components/Tenant/TenantEditWorkflowStatusDialog.vue
@@ -231,9 +231,14 @@ export default {
 
   methods: {
     async fetchRoles() {
-      await ApiRolesService.getTenantRoles(true).then((result) => {
-        this.availableRoles = result?.data;
-      });
+      try {
+        await ApiRolesService.getTenantRoles().then((result) => {
+          this.availableRoles = result?.data;
+        });
+      } catch (error) {
+        console.error("Error fetching roles:", error);
+        this.availableRoles = [];
+      }
     },
     async fetchUsers() {
       await ApiUsersService.getUsers().then((result) => {


### PR DESCRIPTION
This pull request makes a small change to the `fetchRoles` method in the `TenantEditWorkflowStatusDialog` component. The method now uses `getTenantRoles(true)` from `ApiRolesService` instead of `getRoles`. This likely reflects a shift to a more specific API call for tenant roles.