### PR TITLE
added check if booking has price to prevent payment step

### DIFF
--- a/src/views/BundleCheckout/CheckoutGroupBooking.vue
+++ b/src/views/BundleCheckout/CheckoutGroupBooking.vue
@@ -200,7 +200,7 @@ export default {
 
       const steps = [seriesBookingStep, contactDetailsStep];
 
-      if (this.activePaymentApps.length > 1) {
+      if (this.activePaymentApps.length > 1 && this.leadItem.userPriceEur) {
         steps.push(paymentStep);
       }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the checkout flow for group bookings. The payment step is now only added if there is more than one active payment app and the lead item has a defined user price in euros.

- The payment step is conditionally included in the steps array only when both `activePaymentApps.length > 1` and `leadItem.userPriceEur` are truthy, preventing the payment step from showing up when pricing information is missing.