### PR TITLE
added bcc receipt

### DIFF
--- a/src/components/Tenant/TenantEdit.vue
+++ b/src/components/Tenant/TenantEdit.vue
@@ -175,6 +175,16 @@
       </v-row>
       <v-row>
         <v-col>
+          <v-switch
+            v-model="tenant.receiptEnableBCC"
+            color="primary"
+            label="Zahlungsbeleg als Kopie an Mandanten senden"
+            class="mt-2"
+            ></v-switch>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
           <v-text-field
             background-color="accent"
             filled


### PR DESCRIPTION
This pull request introduces a new user interface option to the tenant editing form, allowing users to enable or disable sending payment receipts as a copy to the tenant. This addition enhances the application's configurability for handling payment notifications.

User interface enhancement:

* Added a `v-switch` component bound to the new `tenant.receiptEnableBCC` property, labeled "Zahlungsbeleg als Kopie an Mandanten senden", to the `TenantEdit.vue` form for toggling receipt copy functionality.