### PR TITLE
Fix/new email notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-city-booking-vue-app",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-city-booking-vue-app",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "dependencies": {
         "@babel/core": "^7.23.6",
         "@mdi/font": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-city-booking-vue-app",
   "description": "A VueJS Frontend for the Smart City Booking System",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "scripts": {
     "start": "node --max_old_space_size=4096 node_modules/@vue/cli-service/bin/vue-cli-service.js serve --mode production",

--- a/src/components/Tenant/TenantEdit.vue
+++ b/src/components/Tenant/TenantEdit.vue
@@ -701,6 +701,14 @@
         </v-col>
       </v-row>
       <v-switch
+        v-model="tenant.notifyOnNewBooking"
+        color="primary"
+        hint="Sofern aktiviert, erhält der Mandant eine E-Mail bei jeder neuen Buchung."
+        persistent-hint
+        label="Benachrichtigung bei neuer Buchung"
+        class="mt-2"
+      ></v-switch>
+      <v-switch
         v-model="tenant.enablePublicStatusView"
         color="primary"
         hint="Sofern aktiviert, kann der Status einer Buchung öffentlich abgefragt werden."


### PR DESCRIPTION
This pull request introduces a new feature to the tenant editing interface, allowing users to enable or disable email notifications for new bookings. Additionally, it updates the application version to reflect this change.

Feature addition:

* Added a `v-switch` in `TenantEdit.vue` to allow toggling email notifications for tenants when a new booking is made.

Version update:

* Updated the application version in `package.json` from `3.2.7` to `3.2.8` to reflect the new feature.