### PR TITLE
added keyboard date and time input

### DIFF
--- a/src/views/BundleCheckout/CheckoutTimeSelector.vue
+++ b/src/views/BundleCheckout/CheckoutTimeSelector.vue
@@ -36,10 +36,11 @@
                 v-model="dateBeginModel"
                 label="Startdatum"
                 prepend-icon="mdi-calendar"
-                readonly
+                type="date"
                 v-bind="attrs"
                 v-on="on"
                 :rules="validationRules.dateBegin"
+                @change="$refs.dateBeginMenu.save(dateBeginModel)"
               ></v-text-field>
             </template>
             <v-date-picker
@@ -72,7 +73,7 @@
                 v-model="timeBeginModel"
                 label="Startzeit"
                 prepend-icon="mdi-clock-time-four-outline"
-                readonly
+                type="time"
                 v-bind="attrs"
                 v-on="on"
                 :rules="validationRules.required"
@@ -104,10 +105,11 @@
                 v-model="dateEndModel"
                 label="Enddatum"
                 prepend-icon="mdi-calendar"
-                readonly
+                type="date"
                 v-bind="attrs"
                 v-on="on"
                 :rules="validationRules.dateEnd"
+                @change="$refs.dateEndMenu.save(dateEndModel)"
               ></v-text-field>
             </template>
             <v-date-picker
@@ -140,7 +142,7 @@
                 v-model="timeEndModel"
                 label="Endzeit"
                 prepend-icon="mdi-clock-time-four-outline"
-                readonly
+                type="time"
                 v-bind="attrs"
                 v-on="on"
                 :rules="validationRules.required"


### PR DESCRIPTION
This pull request updates the `CheckoutTimeSelector.vue` component to improve the user experience for selecting start and end dates and times during bundle checkout. The main changes are focused on making the date and time fields interactive and ensuring proper handling of user input.

**Improvements to date and time selection:**

* Changed the `v-text-field` components for `dateBeginModel` and `dateEndModel` to use `type="date"` instead of being read-only, allowing users to input dates directly. [[1]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L39-R43) [[2]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L107-R112)
* Added `@change` event handlers to the date fields to trigger saving the selected dates via `$refs.dateBeginMenu.save(dateBeginModel)` and `$refs.dateEndMenu.save(dateEndModel)`. [[1]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L39-R43) [[2]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L107-R112)
* Updated the `v-text-field` components for `timeBeginModel` and `timeEndModel` to use `type="time"` instead of being read-only, allowing direct time input. [[1]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L75-R76) [[2]](diffhunk://#diff-78d322b700413cc462552aeead1e8128c10d7899e3007f4981cf7fe848243357L143-R145)