### PR TITLE
Fix/calendar availability

### DIFF
--- a/src/components/Checkout/CheckoutCalendar.vue
+++ b/src/components/Checkout/CheckoutCalendar.vue
@@ -171,8 +171,7 @@ export default {
         dateEnd.toISOString().split("T")[0],
         this.amount
       ).then((response) => {
-        // Add new fetched data to the existing data and set new fetchedUntil date
-        this.availabilityItems = this.availabilityItems.concat(response.data);
+        this.availabilityItems = response.data;
         this.fetchedUntil = dateEnd.toISOString().split("T")[0];
         this.loading = false;
       });

--- a/src/components/Checkout/CheckoutCalendar.vue
+++ b/src/components/Checkout/CheckoutCalendar.vue
@@ -142,10 +142,17 @@ export default {
     fetchEvents() {
       // Date Begin is the last fetched date + 1
       let dateBegin = new Date();
+
+      if (this.focus) {
+        dateBegin = new Date(this.focus);
+      }
+
+      /**
       if (this.fetchedUntil) {
         dateBegin = new Date(this.fetchedUntil);
         dateBegin.setTime(dateBegin.getTime() + 1000 * 60 * 60 * 24);
       }
+      */
 
       // The date until data should be loaded is 3 days after the current focus date
       const dateEnd = new Date(this.focus);


### PR DESCRIPTION
This pull request updates the logic for fetching availability data in the `CheckoutCalendar` component to improve how date ranges are determined and how fetched data is managed. The main changes clarify how the fetch window is set and ensure that the displayed availability is always up to date with the latest fetch.

**Improvements to fetch logic:**

* The start date (`dateBegin`) for fetching events now prioritizes the current focus date if available, instead of always using the current date. The previously used logic for incrementing from `fetchedUntil` has been commented out for now.

**Data handling enhancements:**

* When new availability data is fetched, it now replaces the existing `availabilityItems` rather than appending to them, ensuring the displayed data always reflects the most recent fetch.