### PR TITLE
feat(DEV-630): Admin UI for booking lead time (Phase 1)

### DIFF
--- a/src/components/Bookable/BookableEdit.vue
+++ b/src/components/Bookable/BookableEdit.vue
@@ -95,6 +95,7 @@ import BookableEditPrice from "@/components/Bookable/Edit/BookableEditPrice.vue"
 import BookableEditBookingType from "@/components/Bookable/Edit/BookableEditBookingType.vue";
 import SaveBar from "@/components/commons/SaveBar.vue";
 import Bookable from "@/entities/bookable";
+import { normalizeLeadTimeFields } from "@/utils/bookingLeadTime";
 import { mapActions, mapGetters } from "vuex";
 import BookableEditOpeningHours from "@/components/Bookable/Edit/BookableEditOpeningHours.vue";
 import BookableEditLockerSystems from "@/components/Bookable/Edit/BookableEditLockerSystems.vue";
@@ -241,7 +242,7 @@ export default {
         const response = await ApiBookablesService.createOrUpdateBookable(
           this.bookable
         );
-        this.bookable = _.cloneDeep(response.data);
+        this.bookable = normalizeLeadTimeFields(_.cloneDeep(response.data));
 
         if (!this.bookableID) {
           this.$router.replace({
@@ -284,7 +285,9 @@ export default {
         const response = await ApiBookablesService.getBookableTemplate(
           this.currentTenant.id,
         );
-        this.bookable = new Bookable(response.data).toPlain();
+        this.bookable = normalizeLeadTimeFields(
+          new Bookable(response.data).toPlain()
+        );
         this.bookable.type = this.type;
       }
 
@@ -299,7 +302,7 @@ export default {
       try {
         this.isLoading = true;
         const response = await ApiBookablesService.getBookable(bookableId);
-        this.bookable = _.cloneDeep(response.data);
+        this.bookable = normalizeLeadTimeFields(_.cloneDeep(response.data));
       } catch (err) {
         console.error("Error fetching bookable:", err);
       } finally {

--- a/src/components/Bookable/Edit/BookableEditBookingType.vue
+++ b/src/components/Bookable/Edit/BookableEditBookingType.vue
@@ -1,10 +1,11 @@
 <script>
 import BaseSection from "@/components/commons/BaseSection.vue";
+import BookableEditLeadTime from "@/components/Bookable/Edit/BookableEditLeadTime.vue";
 import { v4 as uuidv4 } from "uuid";
 
 export default {
   name: "BookableEditBookingType",
-  components: { BaseSection },
+  components: { BaseSection, BookableEditLeadTime },
   props: { bookable: { type: Object, required: true } },
   data() {
     return {
@@ -108,6 +109,12 @@ export default {
       const formValid = this.$refs.form ? this.$refs.form.validate() : true;
       if (!formValid) {
         return false;
+      }
+      if (this.bookingType === "schedule" && this.$refs.leadTime) {
+        const leadTimeValid = await this.$refs.leadTime.validate();
+        if (!leadTimeValid) {
+          return false;
+        }
       }
       if (this.bookingType !== "blockPeriod") {
         return true;
@@ -431,6 +438,13 @@ export default {
           </v-row>
         </v-card-text>
       </v-card>
+
+      <BookableEditLeadTime
+        v-if="bookingType === 'schedule'"
+        ref="leadTime"
+        :bookable="model"
+        @update:bookable="model = $event"
+      />
 
       <v-card class="mt-4 section-card" v-if="bookingType === 'timePeriod'">
         <v-card-title

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -1,7 +1,7 @@
 <script>
 import {
   formatPreparationDuration,
-  hasLeadTimeConfig,
+  normalizeLeadTimeFields,
 } from "@/utils/bookingLeadTime";
 
 const WEEKDAYS = [
@@ -58,20 +58,23 @@ export default {
     },
   },
   created() {
-    if (!Array.isArray(this.model.serviceHours)) {
-      this.$set(this.model, "serviceHours", []);
-    }
-    if (this.model.preparationLeadTimeMinutes == null) {
-      this.$set(this.model, "preparationLeadTimeMinutes", 0);
-    }
-    const hasExistingLeadTimeConfig = hasLeadTimeConfig(this.model);
-    if (this.model.isLeadTimeRelated == null || hasExistingLeadTimeConfig) {
-      this.$set(this.model, "isLeadTimeRelated", hasExistingLeadTimeConfig);
-    }
+    this.applyLeadTimeStateFromModel();
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
   },
+  watch: {
+    bookable(newBookable, oldBookable) {
+      if (newBookable !== oldBookable) {
+        this.applyLeadTimeStateFromModel();
+        this.syncTimeMenus();
+      }
+    },
+  },
   methods: {
+    applyLeadTimeStateFromModel() {
+      normalizeLeadTimeFields(this.model);
+      this.$set(this.model, "isLeadTimeRelated", this.model.isLeadTimeRelated);
+    },
     syncTimeMenus() {
       const length = this.model.serviceHours?.length || 0;
       if (

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -64,8 +64,9 @@ export default {
     if (this.model.preparationLeadTimeMinutes == null) {
       this.$set(this.model, "preparationLeadTimeMinutes", 0);
     }
-    if (this.model.isLeadTimeRelated == null) {
-      this.$set(this.model, "isLeadTimeRelated", hasLeadTimeConfig(this.model));
+    const hasExistingLeadTimeConfig = hasLeadTimeConfig(this.model);
+    if (this.model.isLeadTimeRelated == null || hasExistingLeadTimeConfig) {
+      this.$set(this.model, "isLeadTimeRelated", hasExistingLeadTimeConfig);
     }
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
@@ -82,9 +83,11 @@ export default {
       }
     },
     setLeadTimeEnabled(enabled) {
+      const wasEnabled = this.leadTimeEnabled;
       this.$set(this.model, "isLeadTimeRelated", enabled);
       if (enabled) {
-        if (this.model.preparationLeadTimeMinutes == null) {
+        const minutes = Number(this.model.preparationLeadTimeMinutes);
+        if (!wasEnabled && (!Number.isFinite(minutes) || minutes <= 0)) {
           this.model.preparationLeadTimeMinutes = 120;
         }
         if (!Array.isArray(this.model.serviceHours)) {

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -1,7 +1,7 @@
 <script>
 import {
   formatPreparationDuration,
-  isLeadTimeSectionEnabled,
+  hasLeadTimeConfig,
 } from "@/utils/bookingLeadTime";
 
 const WEEKDAYS = [
@@ -29,7 +29,6 @@ export default {
   data() {
     return {
       valid: true,
-      leadTimeEnabled: false,
       weekdays: WEEKDAYS,
       presets: PRESET_MINUTES,
       timeStartMenu: [],
@@ -54,6 +53,9 @@ export default {
         Array.isArray(this.model.serviceHours) && this.model.serviceHours.length > 0
       );
     },
+    leadTimeEnabled() {
+      return !!this.model.isLeadTimeRelated;
+    },
   },
   created() {
     if (!Array.isArray(this.model.serviceHours)) {
@@ -62,17 +64,11 @@ export default {
     if (this.model.preparationLeadTimeMinutes == null) {
       this.$set(this.model, "preparationLeadTimeMinutes", 0);
     }
+    if (this.model.isLeadTimeRelated == null) {
+      this.$set(this.model, "isLeadTimeRelated", hasLeadTimeConfig(this.model));
+    }
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
-    this.leadTimeEnabled = isLeadTimeSectionEnabled(this.model);
-  },
-  watch: {
-    bookable(newBookable, oldBookable) {
-      if (newBookable !== oldBookable) {
-        this.leadTimeEnabled = isLeadTimeSectionEnabled(newBookable);
-        this.syncTimeMenus();
-      }
-    },
   },
   methods: {
     syncTimeMenus() {
@@ -86,7 +82,7 @@ export default {
       }
     },
     setLeadTimeEnabled(enabled) {
-      this.leadTimeEnabled = enabled;
+      this.$set(this.model, "isLeadTimeRelated", enabled);
       if (enabled) {
         if (this.model.preparationLeadTimeMinutes == null) {
           this.model.preparationLeadTimeMinutes = 120;
@@ -172,7 +168,7 @@ export default {
       return this.expandedItems.includes(index);
     },
     async validate() {
-      if (!this.leadTimeEnabled) {
+      if (!this.model.isLeadTimeRelated) {
         return true;
       }
       const formValid = this.$refs.form ? this.$refs.form.validate() : true;

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -1,0 +1,507 @@
+<script>
+import { formatPreparationDuration } from "@/utils/bookingLeadTime";
+
+const WEEKDAYS = [
+  { id: 1, name: "Montag", short: "Mo" },
+  { id: 2, name: "Dienstag", short: "Di" },
+  { id: 3, name: "Mittwoch", short: "Mi" },
+  { id: 4, name: "Donnerstag", short: "Do" },
+  { id: 5, name: "Freitag", short: "Fr" },
+  { id: 6, name: "Samstag", short: "Sa" },
+  { id: 0, name: "Sonntag", short: "So" },
+];
+
+const PRESET_MINUTES = [
+  { label: "30 Min.", value: 30 },
+  { label: "1 Std.", value: 60 },
+  { label: "2 Std.", value: 120 },
+  { label: "4 Std.", value: 240 },
+];
+
+export default {
+  name: "BookableEditLeadTime",
+  props: {
+    bookable: { type: Object, required: true },
+  },
+  data() {
+    return {
+      valid: true,
+      weekdays: WEEKDAYS,
+      presets: PRESET_MINUTES,
+      timeStartMenu: [],
+      timeEndMenu: [],
+      expandedItems: [],
+    };
+  },
+  computed: {
+    model: {
+      get() {
+        return this.bookable;
+      },
+      set(val) {
+        this.$emit("update:bookable", { ...val });
+      },
+    },
+    leadTimeEnabled: {
+      get() {
+        return Number(this.model.preparationLeadTimeMinutes) > 0;
+      },
+      set(enabled) {
+        if (enabled) {
+          if (!Number(this.model.preparationLeadTimeMinutes)) {
+            this.model.preparationLeadTimeMinutes = 120;
+          }
+          if (!Array.isArray(this.model.serviceHours)) {
+            this.$set(this.model, "serviceHours", []);
+          }
+          if (this.model.serviceHours.length === 0) {
+            this.addServiceHours();
+          }
+        } else {
+          this.model.preparationLeadTimeMinutes = 0;
+        }
+        this.emitUpdate();
+      },
+    },
+    preparationDurationLabel() {
+      return formatPreparationDuration(this.model.preparationLeadTimeMinutes);
+    },
+    hasServiceHours() {
+      return (
+        Array.isArray(this.model.serviceHours) && this.model.serviceHours.length > 0
+      );
+    },
+  },
+  created() {
+    if (!Array.isArray(this.model.serviceHours)) {
+      this.$set(this.model, "serviceHours", []);
+    }
+    if (this.model.preparationLeadTimeMinutes == null) {
+      this.$set(this.model, "preparationLeadTimeMinutes", 0);
+    }
+  },
+  methods: {
+    emitUpdate() {
+      this.$emit("update:bookable", { ...this.model });
+    },
+    applyPreset(minutes) {
+      this.model.preparationLeadTimeMinutes = minutes;
+      this.emitUpdate();
+    },
+    addServiceHours() {
+      const index = this.model.serviceHours.length;
+      this.timeStartMenu.push(false);
+      this.timeEndMenu.push(false);
+      this.model.serviceHours.push({
+        weekdays: [1, 2, 3, 4, 5],
+        startTime: "08:00",
+        endTime: "18:00",
+      });
+      this.expandedItems.push(index);
+      this.emitUpdate();
+    },
+    removeServiceHours(index) {
+      this.model.serviceHours.splice(index, 1);
+      this.timeStartMenu.splice(index, 1);
+      this.timeEndMenu.splice(index, 1);
+      this.expandedItems = this.expandedItems
+        .filter((expandedIndex) => expandedIndex !== index)
+        .map((expandedIndex) =>
+          expandedIndex > index ? expandedIndex - 1 : expandedIndex
+        );
+      this.emitUpdate();
+    },
+    removeWeekdays(index, weekdayId) {
+      const weekdays = this.model.serviceHours[index].weekdays;
+      weekdays.splice(weekdays.indexOf(weekdayId), 1);
+      this.emitUpdate();
+    },
+    setStartTime(index, time) {
+      this.model.serviceHours[index].startTime = time;
+      this.timeStartMenu[index] = false;
+      this.emitUpdate();
+    },
+    setEndTime(index, time) {
+      this.model.serviceHours[index].endTime = time;
+      this.timeEndMenu[index] = false;
+      this.emitUpdate();
+    },
+    getWeekdayName(id) {
+      const day = this.weekdays.find((entry) => entry.id === Number(id));
+      return day ? day.short : "";
+    },
+    getWeekdayNamesFormatted(weekdayIds) {
+      if (!weekdayIds?.length) {
+        return "";
+      }
+      return weekdayIds
+        .map((id) => this.getWeekdayName(id))
+        .filter(Boolean)
+        .join(", ");
+    },
+    toggleExpand(index) {
+      const idx = this.expandedItems.indexOf(index);
+      if (idx > -1) {
+        this.expandedItems.splice(idx, 1);
+      } else {
+        this.expandedItems.push(index);
+      }
+    },
+    isExpanded(index) {
+      return this.expandedItems.includes(index);
+    },
+    async validate() {
+      if (!this.leadTimeEnabled) {
+        return true;
+      }
+      const formValid = this.$refs.form ? this.$refs.form.validate() : true;
+      if (!formValid) {
+        return false;
+      }
+      return (
+        Number(this.model.preparationLeadTimeMinutes) > 0 &&
+        this.model.serviceHours.length > 0 &&
+        this.model.serviceHours.every(
+          (entry) =>
+            entry.weekdays?.length > 0 && entry.startTime && entry.endTime
+        )
+      );
+    },
+    resetValidation() {
+      this.$refs.form?.resetValidation();
+    },
+  },
+};
+</script>
+
+<template>
+  <v-form ref="form" v-model="valid">
+    <v-card class="mt-4 section-card" outlined>
+      <v-card-title class="section-header pa-4">
+        <v-icon class="mr-2">mdi-timer-sand</v-icon>
+        <span class="text-h6 font-weight-bold">Vorlaufzeit</span>
+      </v-card-title>
+      <v-divider />
+
+      <v-card-text class="pa-4">
+        <v-switch
+          v-model="leadTimeEnabled"
+          color="primary"
+          hide-details
+          class="mt-0"
+        >
+          <template v-slot:label>
+            <div>
+              <div class="font-weight-medium">Vorlaufzeit aktivieren</div>
+              <div class="text-caption text--secondary">
+                Kurzfristige Buchungen verhindern (z. B. Schlüsselübergabe,
+                Raumvorbereitung)
+              </div>
+            </div>
+          </template>
+        </v-switch>
+
+        <template v-if="leadTimeEnabled">
+          <v-divider class="my-4" />
+
+          <v-alert color="info" dense text class="mb-4">
+            <v-icon class="mr-2" color="info" small>
+              mdi-information-outline
+            </v-icon>
+            Die Vorbereitungszeit muss vollständig innerhalb der
+            Servicezeiten liegen – z. B. Freitag 18:00 → Montag 08:00 ist mit
+            2 Std. Vorbereitung nicht möglich.
+          </v-alert>
+
+          <div class="text-subtitle-2 mb-2">Vorbereitungszeit</div>
+          <v-row dense>
+            <v-col cols="12" sm="6" md="4">
+              <v-text-field
+                background-color="accent"
+                filled
+                dense
+                label="Dauer"
+                type="number"
+                min="1"
+                suffix="Minuten"
+                v-model.number="model.preparationLeadTimeMinutes"
+                :hint="
+                  preparationDurationLabel
+                    ? `Entspricht ${preparationDurationLabel}`
+                    : ''
+                "
+                persistent-hint
+                hide-details="auto"
+                :rules="[
+                  (v) => Number(v) > 0 || 'Mindestens 1 Minute erforderlich',
+                ]"
+                @input="emitUpdate"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="8" class="d-flex align-center flex-wrap">
+              <span class="text-caption text--secondary mr-2">Schnellauswahl:</span>
+              <v-chip
+                v-for="preset in presets"
+                :key="preset.value"
+                small
+                class="mr-1 mb-1"
+                :color="
+                  model.preparationLeadTimeMinutes === preset.value
+                    ? 'primary'
+                    : undefined
+                "
+                :outlined="model.preparationLeadTimeMinutes !== preset.value"
+                @click="applyPreset(preset.value)"
+              >
+                {{ preset.label }}
+              </v-chip>
+            </v-col>
+          </v-row>
+
+          <div class="d-flex align-center justify-space-between mt-4 mb-2">
+            <div>
+              <div class="text-subtitle-2">Servicezeiten</div>
+              <div class="text-caption text--secondary">
+                Wann die Vorbereitung stattfinden kann (unabhängig von
+                Öffnungszeiten)
+              </div>
+            </div>
+            <v-btn small color="primary" @click="addServiceHours">
+              <v-icon left small>mdi-plus</v-icon>
+              Hinzufügen
+            </v-btn>
+          </div>
+
+          <div v-if="hasServiceHours">
+            <v-list two-line class="py-0">
+              <template v-for="(entry, index) in model.serviceHours">
+                <v-list-item
+                  :key="`service-hours-${index}`"
+                  class="service-hours-item elevation-1 mb-3 rounded"
+                  @click="toggleExpand(index)"
+                >
+                  <v-list-item-avatar>
+                    <v-avatar
+                      :color="entry.weekdays.length > 0 ? 'primary' : 'grey'"
+                      size="40"
+                    >
+                      <v-icon dark small>mdi-clock-check-outline</v-icon>
+                    </v-avatar>
+                  </v-list-item-avatar>
+
+                  <v-list-item-content>
+                    <v-list-item-title class="font-weight-medium">
+                      {{
+                        getWeekdayNamesFormatted(entry.weekdays) ||
+                        "Keine Tage gewählt"
+                      }}
+                    </v-list-item-title>
+                    <v-list-item-subtitle>
+                      <v-icon small class="mr-1">mdi-clock-outline</v-icon>
+                      <span v-if="entry.startTime && entry.endTime">
+                        {{ entry.startTime }} – {{ entry.endTime }} Uhr
+                      </span>
+                      <span v-else class="grey--text">Zeit nicht gesetzt</span>
+                    </v-list-item-subtitle>
+                  </v-list-item-content>
+
+                  <v-list-item-action>
+                    <div class="d-flex align-center">
+                      <v-btn
+                        icon
+                        small
+                        @click.stop="removeServiceHours(index)"
+                      >
+                        <v-icon small>mdi-delete-outline</v-icon>
+                      </v-btn>
+                      <v-btn icon small>
+                        <v-icon>
+                          {{
+                            isExpanded(index)
+                              ? "mdi-chevron-up"
+                              : "mdi-chevron-down"
+                          }}
+                        </v-icon>
+                      </v-btn>
+                    </div>
+                  </v-list-item-action>
+                </v-list-item>
+
+                <v-expand-transition :key="`service-hours-expand-${index}`">
+                  <v-card
+                    v-show="isExpanded(index)"
+                    flat
+                    class="mx-3 mb-3 pa-4 service-hours-card"
+                    color="grey lighten-5"
+                  >
+                    <v-row>
+                      <v-col cols="12">
+                        <v-select
+                          dense
+                          background-color="accent"
+                          filled
+                          label="Wochentag(e) *"
+                          :items="weekdays"
+                          item-value="id"
+                          item-text="name"
+                          v-model="entry.weekdays"
+                          multiple
+                          chips
+                          hide-selected
+                          hide-details="auto"
+                          :rules="[
+                            (v) =>
+                              (v && v.length > 0) ||
+                              'Mindestens ein Wochentag erforderlich',
+                          ]"
+                          @change="emitUpdate"
+                        >
+                          <template
+                            v-slot:selection="{ attrs, item, select, selected }"
+                          >
+                            <v-chip
+                              v-bind="attrs"
+                              :input-value="selected"
+                              close
+                              small
+                              color="secondary"
+                              @click="select"
+                              @click:close="removeWeekdays(index, item.id)"
+                            >
+                              <strong>{{ item.name }}</strong>
+                            </v-chip>
+                          </template>
+                        </v-select>
+                      </v-col>
+                    </v-row>
+
+                    <v-row>
+                      <v-col cols="12" md="6">
+                        <v-menu
+                          v-model="timeStartMenu[index]"
+                          :close-on-content-click="false"
+                          :nudge-right="40"
+                          transition="scale-transition"
+                          offset-y
+                          max-width="290px"
+                          min-width="290px"
+                        >
+                          <template v-slot:activator="{ on, attrs }">
+                            <v-text-field
+                              dense
+                              background-color="accent"
+                              filled
+                              v-model="entry.startTime"
+                              label="Startzeit *"
+                              readonly
+                              suffix="Uhr"
+                              v-bind="attrs"
+                              v-on="on"
+                              hide-details="auto"
+                              :rules="[
+                                (v) => !!v || 'Startzeit ist erforderlich',
+                              ]"
+                            />
+                          </template>
+                          <v-time-picker
+                            v-if="timeStartMenu[index]"
+                            v-model="entry.startTime"
+                            full-width
+                            format="24hr"
+                            @click:minute="setStartTime(index, entry.startTime)"
+                          />
+                        </v-menu>
+                      </v-col>
+
+                      <v-col cols="12" md="6">
+                        <v-menu
+                          v-model="timeEndMenu[index]"
+                          :close-on-content-click="false"
+                          :nudge-right="40"
+                          transition="scale-transition"
+                          offset-y
+                          max-width="290px"
+                          min-width="290px"
+                        >
+                          <template v-slot:activator="{ on, attrs }">
+                            <v-text-field
+                              dense
+                              background-color="accent"
+                              filled
+                              v-model="entry.endTime"
+                              label="Endzeit *"
+                              readonly
+                              suffix="Uhr"
+                              v-bind="attrs"
+                              v-on="on"
+                              hide-details="auto"
+                              :rules="[
+                                (v) => !!v || 'Endzeit ist erforderlich',
+                              ]"
+                            />
+                          </template>
+                          <v-time-picker
+                            v-if="timeEndMenu[index]"
+                            v-model="entry.endTime"
+                            full-width
+                            format="24hr"
+                            @click:minute="setEndTime(index, entry.endTime)"
+                          />
+                        </v-menu>
+                      </v-col>
+                    </v-row>
+                  </v-card>
+                </v-expand-transition>
+              </template>
+            </v-list>
+          </div>
+
+          <div v-else class="text-center py-6">
+            <div class="text-body-2 grey--text mb-3">
+              Mindestens ein Servicezeiten-Fenster ist erforderlich.
+            </div>
+            <v-btn small text color="primary" @click="addServiceHours">
+              <v-icon left small>mdi-plus</v-icon>
+              Servicezeiten hinzufügen
+            </v-btn>
+          </div>
+        </template>
+      </v-card-text>
+    </v-card>
+  </v-form>
+</template>
+
+<style scoped>
+.section-card {
+  border-radius: 8px !important;
+}
+
+.section-header {
+  background: linear-gradient(
+    135deg,
+    rgba(0, 0, 0, 0.02) 0%,
+    rgba(0, 0, 0, 0.01) 100%
+  );
+}
+
+.theme--dark .section-header {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+}
+
+.service-hours-item {
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.theme--dark .service-hours-item {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.service-hours-card {
+  border-radius: 8px !important;
+}
+</style>

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -79,6 +79,8 @@ export default {
     if (this.model.preparationLeadTimeMinutes == null) {
       this.$set(this.model, "preparationLeadTimeMinutes", 0);
     }
+    this.timeStartMenu = this.model.serviceHours.map(() => false);
+    this.timeEndMenu = this.model.serviceHours.map(() => false);
   },
   methods: {
     emitUpdate() {

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -1,5 +1,8 @@
 <script>
-import { formatPreparationDuration } from "@/utils/bookingLeadTime";
+import {
+  formatPreparationDuration,
+  isLeadTimeSectionEnabled,
+} from "@/utils/bookingLeadTime";
 
 const WEEKDAYS = [
   { id: 1, name: "Montag", short: "Mo" },
@@ -26,6 +29,7 @@ export default {
   data() {
     return {
       valid: true,
+      leadTimeEnabled: false,
       weekdays: WEEKDAYS,
       presets: PRESET_MINUTES,
       timeStartMenu: [],
@@ -40,27 +44,6 @@ export default {
       },
       set(val) {
         this.$emit("update:bookable", { ...val });
-      },
-    },
-    leadTimeEnabled: {
-      get() {
-        return Number(this.model.preparationLeadTimeMinutes) > 0;
-      },
-      set(enabled) {
-        if (enabled) {
-          if (!Number(this.model.preparationLeadTimeMinutes)) {
-            this.model.preparationLeadTimeMinutes = 120;
-          }
-          if (!Array.isArray(this.model.serviceHours)) {
-            this.$set(this.model, "serviceHours", []);
-          }
-          if (this.model.serviceHours.length === 0) {
-            this.addServiceHours();
-          }
-        } else {
-          this.model.preparationLeadTimeMinutes = 0;
-        }
-        this.emitUpdate();
       },
     },
     preparationDurationLabel() {
@@ -81,8 +64,44 @@ export default {
     }
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
+    this.leadTimeEnabled = isLeadTimeSectionEnabled(this.model);
+  },
+  watch: {
+    bookable(newBookable, oldBookable) {
+      if (newBookable !== oldBookable) {
+        this.leadTimeEnabled = isLeadTimeSectionEnabled(newBookable);
+        this.syncTimeMenus();
+      }
+    },
   },
   methods: {
+    syncTimeMenus() {
+      const length = this.model.serviceHours?.length || 0;
+      if (
+        this.timeStartMenu.length !== length ||
+        this.timeEndMenu.length !== length
+      ) {
+        this.timeStartMenu = Array.from({ length }, () => false);
+        this.timeEndMenu = Array.from({ length }, () => false);
+      }
+    },
+    setLeadTimeEnabled(enabled) {
+      this.leadTimeEnabled = enabled;
+      if (enabled) {
+        if (this.model.preparationLeadTimeMinutes == null) {
+          this.model.preparationLeadTimeMinutes = 120;
+        }
+        if (!Array.isArray(this.model.serviceHours)) {
+          this.$set(this.model, "serviceHours", []);
+        }
+        if (this.model.serviceHours.length === 0) {
+          this.addServiceHours();
+        }
+      } else {
+        this.model.preparationLeadTimeMinutes = 0;
+      }
+      this.emitUpdate();
+    },
     emitUpdate() {
       this.$emit("update:bookable", { ...this.model });
     },
@@ -161,13 +180,17 @@ export default {
         return false;
       }
       return (
-        Number(this.model.preparationLeadTimeMinutes) > 0 &&
+        this.isPreparationMinutesValid() &&
         this.model.serviceHours.length > 0 &&
         this.model.serviceHours.every(
           (entry) =>
             entry.weekdays?.length > 0 && entry.startTime && entry.endTime
         )
       );
+    },
+    isPreparationMinutesValid() {
+      const minutes = Number(this.model.preparationLeadTimeMinutes);
+      return !Number.isNaN(minutes) && minutes >= 0;
     },
     resetValidation() {
       this.$refs.form?.resetValidation();
@@ -187,10 +210,11 @@ export default {
 
       <v-card-text class="pa-4">
         <v-switch
-          v-model="leadTimeEnabled"
+          :input-value="leadTimeEnabled"
           color="primary"
           hide-details
           class="mt-0"
+          @change="setLeadTimeEnabled"
         >
           <template v-slot:label>
             <div>
@@ -224,7 +248,7 @@ export default {
                 dense
                 label="Dauer"
                 type="number"
-                min="1"
+                min="0"
                 suffix="Minuten"
                 v-model.number="model.preparationLeadTimeMinutes"
                 :hint="
@@ -235,7 +259,12 @@ export default {
                 persistent-hint
                 hide-details="auto"
                 :rules="[
-                  (v) => Number(v) > 0 || 'Mindestens 1 Minute erforderlich',
+                  (v) =>
+                    (v !== '' &&
+                      v != null &&
+                      !Number.isNaN(Number(v)) &&
+                      Number(v) >= 0) ||
+                    'Gültige Dauer erforderlich',
                 ]"
                 @input="emitUpdate"
               />

--- a/src/components/Booking/BookingEdit.vue
+++ b/src/components/Booking/BookingEdit.vue
@@ -278,6 +278,18 @@
               belegt. Als Admin können Sie trotzdem fortfahren.
             </v-alert>
 
+            <v-alert
+              v-if="hasLeadTimeBookables"
+              type="info"
+              dense
+              text
+              class="mt-3 mb-0 caption"
+            >
+              Mindestens ein Buchungsobjekt hat eine Vorlaufzeit konfiguriert.
+              Bei manuellen Buchungen wird diese Regel nicht geprüft – sie gilt
+              nur im öffentlichen Checkout.
+            </v-alert>
+
             <div class="d-flex align-center justify-space-between mt-4 mb-1">
               <span class="text-subtitle-2">Buchungszeitraum</span>
               <v-btn x-small text @click="removeBookingTimes">
@@ -860,6 +872,7 @@ import CheckoutCalendar from "@/components/Checkout/CheckoutCalendar.vue";
 import { getTypeColor, getTypeIcon, getTypeText } from "@/utils/bookables";
 import { isTimeDependentBookable } from "@/utils/bookableBookingMode";
 import { formatCheckoutValidationError } from "@/utils/checkoutErrors";
+import { hasLeadTimeConfig } from "@/utils/bookingLeadTime";
 import {
   resolveBookingCheckoutCustomFields,
   setCustomFieldValue,
@@ -1066,6 +1079,11 @@ export default {
     },
     showOccupancyCalendar() {
       return !!this.calendarBookableItem;
+    },
+    hasLeadTimeBookables() {
+      return this.bookableItems.some((item) =>
+        hasLeadTimeConfig(item._bookableUsed)
+      );
     },
     hasUnsavedChanges() {
       if (!this.originalSnapshot || !this.editableBooking) return false;

--- a/src/components/commons/SaveBar.vue
+++ b/src/components/commons/SaveBar.vue
@@ -178,7 +178,7 @@ export default {
 .save-bar-wrapper {
   position: fixed;
   bottom: 12px;
-  z-index: 10;
+  z-index: 4;
   pointer-events: none;
   padding-bottom: calc(var(--save-bar-gap) + env(safe-area-inset-bottom));
 }

--- a/src/entities/bookable.js
+++ b/src/entities/bookable.js
@@ -32,6 +32,9 @@ export default class Bookable {
     this.isBlockPeriodRelated = false;
     this.blockPeriods = [];
 
+    this.preparationLeadTimeMinutes = 0;
+    this.serviceHours = [];
+
     this.priceCategories = [
       {
         priceEur: 0,

--- a/src/entities/bookable.js
+++ b/src/entities/bookable.js
@@ -32,6 +32,7 @@ export default class Bookable {
     this.isBlockPeriodRelated = false;
     this.blockPeriods = [];
 
+    this.isLeadTimeRelated = false;
     this.preparationLeadTimeMinutes = 0;
     this.serviceHours = [];
 

--- a/src/language/de/translations.json
+++ b/src/language/de/translations.json
@@ -451,6 +451,10 @@
       "title": "Ungültiger Zeitraum",
       "message": "Für dieses Objekt muss ein vollständiger Zeitraum gebucht werden."
     },
+    "insufficient-lead-time": {
+      "title": "Vorlaufzeit nicht eingehalten",
+      "message": "Die Buchung liegt zu kurzfristig. Zwischen Buchung und Beginn muss ausreichend Vorbereitungszeit in den Servicezeiten liegen."
+    },
     "block_period": {
       "unavailable": {
         "availability": "Bereits ausgebucht",

--- a/src/store/modules/bookables.js
+++ b/src/store/modules/bookables.js
@@ -37,6 +37,7 @@ const state = {
     isBlockPeriodRelated: false,
     blockPeriods: [],
 
+    isLeadTimeRelated: false,
     preparationLeadTimeMinutes: 0,
     serviceHours: [],
 
@@ -135,6 +136,7 @@ const mutations = {
       isBlockPeriodRelated: false,
       blockPeriods: [],
 
+      isLeadTimeRelated: false,
       preparationLeadTimeMinutes: 0,
       serviceHours: [],
 

--- a/src/store/modules/bookables.js
+++ b/src/store/modules/bookables.js
@@ -37,6 +37,9 @@ const state = {
     isBlockPeriodRelated: false,
     blockPeriods: [],
 
+    preparationLeadTimeMinutes: 0,
+    serviceHours: [],
+
     priceCategories: [
       {
         priceEur: 0,
@@ -131,6 +134,9 @@ const mutations = {
       longRangeOptions: null,
       isBlockPeriodRelated: false,
       blockPeriods: [],
+
+      preparationLeadTimeMinutes: 0,
+      serviceHours: [],
 
       priceCategories: [
         {

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -1,0 +1,35 @@
+export function hasLeadTimeConfig(bookable) {
+  if (!bookable?.isScheduleRelated) {
+    return false;
+  }
+  const minutes = Number(bookable.preparationLeadTimeMinutes);
+  const serviceHours = bookable.serviceHours;
+  return (
+    minutes > 0 &&
+    Array.isArray(serviceHours) &&
+    serviceHours.length > 0 &&
+    serviceHours.some(
+      (entry) =>
+        Array.isArray(entry.weekdays) &&
+        entry.weekdays.length > 0 &&
+        entry.startTime &&
+        entry.endTime
+    )
+  );
+}
+
+export function formatPreparationDuration(minutes) {
+  const value = Number(minutes);
+  if (!value || value <= 0) {
+    return "";
+  }
+  const hours = Math.floor(value / 60);
+  const mins = value % 60;
+  if (hours > 0 && mins > 0) {
+    return `${hours} Std. ${mins} Min.`;
+  }
+  if (hours > 0) {
+    return `${hours} Std.`;
+  }
+  return `${mins} Min.`;
+}

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -18,6 +18,15 @@ export function hasLeadTimeConfig(bookable) {
   );
 }
 
+export function isLeadTimeSectionEnabled(bookable) {
+  if (!bookable?.isScheduleRelated) {
+    return false;
+  }
+  const hasServiceHours =
+    Array.isArray(bookable.serviceHours) && bookable.serviceHours.length > 0;
+  return hasServiceHours || Number(bookable.preparationLeadTimeMinutes) > 0;
+}
+
 export function formatPreparationDuration(minutes) {
   const value = Number(minutes);
   if (!value || value <= 0) {

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -18,15 +18,6 @@ export function hasLeadTimeConfig(bookable) {
   );
 }
 
-export function isLeadTimeSectionEnabled(bookable) {
-  if (!bookable?.isScheduleRelated) {
-    return false;
-  }
-  const hasServiceHours =
-    Array.isArray(bookable.serviceHours) && bookable.serviceHours.length > 0;
-  return hasServiceHours || Number(bookable.preparationLeadTimeMinutes) > 0;
-}
-
 export function formatPreparationDuration(minutes) {
   const value = Number(minutes);
   if (!value || value <= 0) {

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -18,6 +18,35 @@ export function hasLeadTimeConfig(bookable) {
   );
 }
 
+export function normalizeLeadTimeFields(bookable) {
+  if (!bookable) {
+    return bookable;
+  }
+
+  if (!Array.isArray(bookable.serviceHours)) {
+    bookable.serviceHours = [];
+  }
+  if (bookable.preparationLeadTimeMinutes == null) {
+    bookable.preparationLeadTimeMinutes = 0;
+  }
+
+  if (!bookable.isScheduleRelated) {
+    bookable.isLeadTimeRelated = false;
+    return bookable;
+  }
+
+  const hasExistingLeadTimeConfig = hasLeadTimeConfig(bookable);
+  const hasServiceHours = bookable.serviceHours.length > 0;
+
+  if (hasExistingLeadTimeConfig || hasServiceHours) {
+    bookable.isLeadTimeRelated = true;
+  } else if (bookable.isLeadTimeRelated == null) {
+    bookable.isLeadTimeRelated = false;
+  }
+
+  return bookable;
+}
+
 export function formatPreparationDuration(minutes) {
   const value = Number(minutes);
   if (!value || value <= 0) {


### PR DESCRIPTION
## Summary
- Add admin configuration for lead time on bookables with booking type "Free time selection" (`isScheduleRelated`)
- Fields: `preparationLeadTimeMinutes` (preparation time) and `serviceHours` (service hours editor)
- Compact UI with enable switch, quick-select presets, and collapsible service-hours editor in the "Booking type" tab
- Info notice on manual booking: lead time applies only in public checkout, not for admins
- German translation added for checkout error code `insufficient-lead-time`
- Follow-up fixes:
  - Decouple UI toggle state from backend-active check (`isLeadTimeSectionEnabled` vs `hasLeadTimeConfig`)
  - Allow entering `0` for preparation time without collapsing the section
  - Lower SaveBar z-index so selects/popovers render above the fixed bar

## Test plan
- [x] Open a bookable with "Free time selection" → tab "Booking type" → enable lead time
- [x] Set preparation time (manually or via preset) and configure service hours
- [x] Save and reload → values persist
- [x] Enter `0` for preparation time → section stays open
- [x] Disable lead time via switch → `preparationLeadTimeMinutes` is set to `0`
- [x] Manual booking with lead-time bookable → info notice visible
- [x] Other booking types → lead time section hidden
- [x] Open select/time picker near bottom of page → dropdown appears above SaveBar

## Links
- Backend: ECCdigital/smart-city-booking-backend#205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added lead-time editing for bookable items, including preparation duration and optional service-hour windows.
  * For schedule-based booking types, added an embedded lead-time form with validation gating.
  * Show an informational warning during booking when selected items require lead time, plus a checkout message when requirements aren’t met.

* **Bug Fixes**
  * Improved data initialization and reset/clear behavior to consistently include lead-time fields.
  * Enhanced lead-time configuration validation to ensure required values (duration and service windows) are complete.

* **Style**
  * Adjusted save bar stacking order for better overlap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->