### PR TITLE
feat(DEV-630): Admin UI Phase 2 – booking gap buffers

### DIFF
--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -23,7 +23,7 @@ const PRESET_MINUTES = [
 ];
 
 const BUFFER_PRESET_MINUTES = [
-  { label: "Aus", value: 0 },
+  { label: "Keiner", value: 0 },
   { label: "15 Min.", value: 15 },
   { label: "30 Min.", value: 30 },
 ];
@@ -42,7 +42,6 @@ export default {
       timeStartMenu: [],
       timeEndMenu: [],
       expandedItems: [],
-      bufferExpanded: false,
     };
   },
   computed: {
@@ -65,28 +64,12 @@ export default {
     leadTimeEnabled() {
       return !!this.model.isLeadTimeRelated;
     },
-    bufferEnabled() {
-      return hasBufferConfig(this.model);
-    },
-    bufferSummary() {
-      const before = Number(this.model.bufferTimeBeforeMinutes) || 0;
-      const after = Number(this.model.bufferTimeAfterMinutes) || 0;
-      if (before <= 0 && after <= 0) {
-        return "Kein Puffer aktiv";
-      }
-      const parts = [];
-      if (before > 0) {
-        parts.push(`${formatPreparationDuration(before)} vorher`);
-      }
-      if (after > 0) {
-        parts.push(`${formatPreparationDuration(after)} nachher`);
-      }
-      return parts.join(" · ");
+    bufferSwitchEnabled() {
+      return !!this.model.isBufferRelated;
     },
   },
   created() {
     this.applyLeadTimeStateFromModel();
-    this.bufferExpanded = hasBufferConfig(this.model);
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
   },
@@ -95,9 +78,6 @@ export default {
       if (newBookable !== oldBookable) {
         this.applyLeadTimeStateFromModel();
         this.syncTimeMenus();
-        if (hasBufferConfig(newBookable)) {
-          this.bufferExpanded = true;
-        }
       }
     },
   },
@@ -105,6 +85,7 @@ export default {
     applyLeadTimeStateFromModel() {
       normalizeLeadTimeFields(this.model);
       this.$set(this.model, "isLeadTimeRelated", this.model.isLeadTimeRelated);
+      this.$set(this.model, "isBufferRelated", this.model.isBufferRelated);
     },
     syncTimeMenus() {
       const length = this.model.serviceHours?.length || 0;
@@ -132,6 +113,19 @@ export default {
         }
       } else {
         this.model.preparationLeadTimeMinutes = 0;
+      }
+      this.emitUpdate();
+    },
+    setBufferEnabled(enabled) {
+      const wasEnabled = this.bufferSwitchEnabled;
+      this.$set(this.model, "isBufferRelated", enabled);
+      if (enabled) {
+        if (!wasEnabled && !hasBufferConfig(this.model)) {
+          this.model.bufferTimeAfterMinutes = 30;
+        }
+      } else {
+        this.model.bufferTimeBeforeMinutes = null;
+        this.model.bufferTimeAfterMinutes = null;
       }
       this.emitUpdate();
     },
@@ -237,22 +231,22 @@ export default {
       if (!formValid) {
         return false;
       }
-      if (!this.model.isLeadTimeRelated) {
-        return (
-          this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
-          this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes)
-        );
-      }
-      return (
-        this.isPreparationMinutesValid() &&
-        this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
-        this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes) &&
-        this.model.serviceHours.length > 0 &&
-        this.model.serviceHours.every(
-          (entry) =>
-            entry.weekdays?.length > 0 && entry.startTime && entry.endTime
-        )
-      );
+
+      const leadTimeValid =
+        !this.model.isLeadTimeRelated ||
+        (this.isPreparationMinutesValid() &&
+          this.model.serviceHours.length > 0 &&
+          this.model.serviceHours.every(
+            (entry) =>
+              entry.weekdays?.length > 0 && entry.startTime && entry.endTime
+          ));
+
+      const bufferValid =
+        !this.model.isBufferRelated ||
+        (this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
+          this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes));
+
+      return leadTimeValid && bufferValid;
     },
     isPreparationMinutesValid() {
       const minutes = Number(this.model.preparationLeadTimeMinutes);
@@ -563,138 +557,135 @@ export default {
             </v-btn>
           </div>
         </template>
+      </v-card-text>
+    </v-card>
 
-        <v-divider class="my-4" />
+    <v-card class="mt-4 section-card" outlined>
+      <v-card-title class="section-header pa-4">
+        <v-icon class="mr-2">mdi-calendar-clock</v-icon>
+        <span class="text-h6 font-weight-bold">Puffer zwischen Buchungen</span>
+      </v-card-title>
+      <v-divider />
 
-        <div
-          class="buffer-section-header d-flex align-center"
-          role="button"
-          tabindex="0"
-          @click="bufferExpanded = !bufferExpanded"
-          @keydown.enter.prevent="bufferExpanded = !bufferExpanded"
-          @keydown.space.prevent="bufferExpanded = !bufferExpanded"
+      <v-card-text class="pa-4">
+        <v-switch
+          :input-value="bufferSwitchEnabled"
+          color="primary"
+          hide-details
+          class="mt-0"
+          @change="setBufferEnabled"
         >
-          <v-icon class="mr-2" small>mdi-calendar-remove-outline</v-icon>
-          <div class="flex-grow-1">
-            <div class="text-subtitle-2">Kapazitäts-Puffer</div>
-            <div class="text-caption text--secondary">
-              {{ bufferSummary }}
+          <template v-slot:label>
+            <div>
+              <div class="font-weight-medium">
+                Puffer zwischen Buchungen aktivieren
+              </div>
+              <div class="text-caption text--secondary">
+                Mindestabstand vor und nach bestehenden Buchungen (z. B.
+                Reinigung, Umräumen)
+              </div>
             </div>
-          </div>
-          <v-chip
-            v-if="bufferEnabled"
-            x-small
-            color="primary"
-            text-color="white"
-            class="mr-2"
-          >
-            Aktiv
-          </v-chip>
-          <v-icon small>
-            {{ bufferExpanded ? "mdi-chevron-up" : "mdi-chevron-down" }}
-          </v-icon>
-        </div>
+          </template>
+        </v-switch>
 
-        <v-expand-transition>
-          <div v-show="bufferExpanded" class="mt-3">
-            <v-alert color="grey" dense text class="mb-4 caption">
-              Verhindert direkt aufeinanderfolgende Buchungen. Gilt nicht bei
-              manueller Buchung mit Berechtigung.
-            </v-alert>
+        <template v-if="bufferSwitchEnabled">
+          <v-divider class="my-4" />
 
-            <v-row dense>
-              <v-col cols="12" md="6">
-                <div class="text-caption font-weight-medium mb-1">
-                  Puffer vor Buchung
-                </div>
-                <div class="text-caption text--secondary mb-2">
-                  z. B. Reinigung oder Vorbereitung vor dem Termin
-                </div>
-                <v-text-field
-                  background-color="accent"
-                  filled
-                  dense
-                  label="Dauer"
-                  type="number"
-                  min="0"
-                  suffix="Minuten"
-                  :value="displayBufferMinutes(model.bufferTimeBeforeMinutes)"
-                  hide-details="auto"
-                  :rules="[
-                    (v) =>
-                      isBufferMinutesValid(v) ||
-                      'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
-                  ]"
-                  @input="setBufferMinutes('bufferTimeBeforeMinutes', $event)"
-                />
-                <div class="d-flex flex-wrap mt-2">
-                  <v-chip
-                    v-for="preset in bufferPresets"
-                    :key="`before-${preset.value}`"
-                    x-small
-                    class="mr-1 mb-1"
-                    :color="
-                      bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
-                        ? 'primary'
-                        : undefined
-                    "
-                    :outlined="
-                      !bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
-                    "
-                    @click="applyBufferPreset('bufferTimeBeforeMinutes', preset.value)"
-                  >
-                    {{ preset.label }}
-                  </v-chip>
-                </div>
-              </v-col>
+          <v-alert color="grey" dense text class="mb-4 caption">
+            Verhindert direkt aufeinanderfolgende Buchungen. Gilt nicht bei
+            manueller Buchung mit Berechtigung.
+          </v-alert>
 
-              <v-col cols="12" md="6">
-                <div class="text-caption font-weight-medium mb-1">
-                  Puffer nach Buchung
-                </div>
-                <div class="text-caption text--secondary mb-2">
-                  z. B. Nachbereitung oder Umräumen
-                </div>
-                <v-text-field
-                  background-color="accent"
-                  filled
-                  dense
-                  label="Dauer"
-                  type="number"
-                  min="0"
-                  suffix="Minuten"
-                  :value="displayBufferMinutes(model.bufferTimeAfterMinutes)"
-                  hide-details="auto"
-                  :rules="[
-                    (v) =>
-                      isBufferMinutesValid(v) ||
-                      'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
-                  ]"
-                  @input="setBufferMinutes('bufferTimeAfterMinutes', $event)"
-                />
-                <div class="d-flex flex-wrap mt-2">
-                  <v-chip
-                    v-for="preset in bufferPresets"
-                    :key="`after-${preset.value}`"
-                    x-small
-                    class="mr-1 mb-1"
-                    :color="
-                      bufferPresetActive('bufferTimeAfterMinutes', preset.value)
-                        ? 'primary'
-                        : undefined
-                    "
-                    :outlined="
-                      !bufferPresetActive('bufferTimeAfterMinutes', preset.value)
-                    "
-                    @click="applyBufferPreset('bufferTimeAfterMinutes', preset.value)"
-                  >
-                    {{ preset.label }}
-                  </v-chip>
-                </div>
-              </v-col>
-            </v-row>
-          </div>
-        </v-expand-transition>
+          <v-row dense>
+            <v-col cols="12" md="6">
+              <div class="text-subtitle-2 mb-1">Vor der Buchung</div>
+              <div class="text-caption text--secondary mb-2">
+                Zeit, die vor dem Terminbeginn blockiert wird
+              </div>
+              <v-text-field
+                background-color="accent"
+                filled
+                dense
+                label="Dauer"
+                type="number"
+                min="0"
+                suffix="Minuten"
+                :value="displayBufferMinutes(model.bufferTimeBeforeMinutes)"
+                hide-details="auto"
+                :rules="[
+                  (v) =>
+                    isBufferMinutesValid(v) ||
+                    'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
+                ]"
+                @input="setBufferMinutes('bufferTimeBeforeMinutes', $event)"
+              />
+              <div class="d-flex flex-wrap mt-2">
+                <span class="text-caption text--secondary mr-2">Schnellauswahl:</span>
+                <v-chip
+                  v-for="preset in bufferPresets"
+                  :key="`before-${preset.value}`"
+                  x-small
+                  class="mr-1 mb-1"
+                  :color="
+                    bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
+                      ? 'primary'
+                      : undefined
+                  "
+                  :outlined="
+                    !bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
+                  "
+                  @click="applyBufferPreset('bufferTimeBeforeMinutes', preset.value)"
+                >
+                  {{ preset.label }}
+                </v-chip>
+              </div>
+            </v-col>
+
+            <v-col cols="12" md="6">
+              <div class="text-subtitle-2 mb-1">Nach der Buchung</div>
+              <div class="text-caption text--secondary mb-2">
+                Zeit, die nach dem Terminende blockiert wird
+              </div>
+              <v-text-field
+                background-color="accent"
+                filled
+                dense
+                label="Dauer"
+                type="number"
+                min="0"
+                suffix="Minuten"
+                :value="displayBufferMinutes(model.bufferTimeAfterMinutes)"
+                hide-details="auto"
+                :rules="[
+                  (v) =>
+                    isBufferMinutesValid(v) ||
+                    'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
+                ]"
+                @input="setBufferMinutes('bufferTimeAfterMinutes', $event)"
+              />
+              <div class="d-flex flex-wrap mt-2">
+                <span class="text-caption text--secondary mr-2">Schnellauswahl:</span>
+                <v-chip
+                  v-for="preset in bufferPresets"
+                  :key="`after-${preset.value}`"
+                  x-small
+                  class="mr-1 mb-1"
+                  :color="
+                    bufferPresetActive('bufferTimeAfterMinutes', preset.value)
+                      ? 'primary'
+                      : undefined
+                  "
+                  :outlined="
+                    !bufferPresetActive('bufferTimeAfterMinutes', preset.value)
+                  "
+                  @click="applyBufferPreset('bufferTimeAfterMinutes', preset.value)"
+                >
+                  {{ preset.label }}
+                </v-chip>
+              </div>
+            </v-col>
+          </v-row>
+        </template>
       </v-card-text>
     </v-card>
   </v-form>
@@ -719,24 +710,6 @@ export default {
     rgba(255, 255, 255, 0.05) 0%,
     rgba(255, 255, 255, 0.02) 100%
   );
-}
-
-.buffer-section-header {
-  cursor: pointer;
-  border-radius: 8px;
-  padding: 8px 4px;
-  transition: background-color 0.2s ease;
-}
-
-.buffer-section-header:hover,
-.buffer-section-header:focus {
-  background-color: rgba(0, 0, 0, 0.04);
-  outline: none;
-}
-
-.theme--dark .buffer-section-header:hover,
-.theme--dark .buffer-section-header:focus {
-  background-color: rgba(255, 255, 255, 0.06);
 }
 
 .service-hours-item {

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -261,7 +261,7 @@ export default {
 
 <template>
   <v-form ref="form" v-model="valid">
-    <v-card class="mt-4 section-card" outlined>
+    <v-card class="mt-4 section-card" elevation="2" outlined>
       <v-card-title class="section-header pa-4">
         <v-icon class="mr-2">mdi-timer-sand</v-icon>
         <span class="text-h6 font-weight-bold">Vorlaufzeit</span>
@@ -560,7 +560,7 @@ export default {
       </v-card-text>
     </v-card>
 
-    <v-card class="mt-4 section-card" outlined>
+    <v-card class="mt-4 section-card" elevation="2" outlined>
       <v-card-title class="section-header pa-4">
         <v-icon class="mr-2">mdi-calendar-clock</v-icon>
         <span class="text-h6 font-weight-bold">Puffer zwischen Buchungen</span>
@@ -590,11 +590,6 @@ export default {
 
         <template v-if="bufferSwitchEnabled">
           <v-divider class="my-4" />
-
-          <v-alert color="grey" dense text class="mb-4 caption">
-            Verhindert direkt aufeinanderfolgende Buchungen. Gilt nicht bei
-            manueller Buchung mit Berechtigung.
-          </v-alert>
 
           <v-row dense>
             <v-col cols="12" md="6">

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -244,7 +244,8 @@ export default {
       const bufferValid =
         !this.model.isBufferRelated ||
         (this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
-          this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes));
+          this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes) &&
+          hasBufferConfig(this.model));
 
       return leadTimeValid && bufferValid;
     },

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -1,6 +1,7 @@
 <script>
 import {
   formatPreparationDuration,
+  hasBufferConfig,
   normalizeLeadTimeFields,
 } from "@/utils/bookingLeadTime";
 
@@ -21,6 +22,12 @@ const PRESET_MINUTES = [
   { label: "4 Std.", value: 240 },
 ];
 
+const BUFFER_PRESET_MINUTES = [
+  { label: "Aus", value: 0 },
+  { label: "15 Min.", value: 15 },
+  { label: "30 Min.", value: 30 },
+];
+
 export default {
   name: "BookableEditLeadTime",
   props: {
@@ -31,9 +38,11 @@ export default {
       valid: true,
       weekdays: WEEKDAYS,
       presets: PRESET_MINUTES,
+      bufferPresets: BUFFER_PRESET_MINUTES,
       timeStartMenu: [],
       timeEndMenu: [],
       expandedItems: [],
+      bufferExpanded: false,
     };
   },
   computed: {
@@ -56,9 +65,28 @@ export default {
     leadTimeEnabled() {
       return !!this.model.isLeadTimeRelated;
     },
+    bufferEnabled() {
+      return hasBufferConfig(this.model);
+    },
+    bufferSummary() {
+      const before = Number(this.model.bufferTimeBeforeMinutes) || 0;
+      const after = Number(this.model.bufferTimeAfterMinutes) || 0;
+      if (before <= 0 && after <= 0) {
+        return "Kein Puffer aktiv";
+      }
+      const parts = [];
+      if (before > 0) {
+        parts.push(`${formatPreparationDuration(before)} vorher`);
+      }
+      if (after > 0) {
+        parts.push(`${formatPreparationDuration(after)} nachher`);
+      }
+      return parts.join(" · ");
+    },
   },
   created() {
     this.applyLeadTimeStateFromModel();
+    this.bufferExpanded = hasBufferConfig(this.model);
     this.timeStartMenu = this.model.serviceHours.map(() => false);
     this.timeEndMenu = this.model.serviceHours.map(() => false);
   },
@@ -67,6 +95,9 @@ export default {
       if (newBookable !== oldBookable) {
         this.applyLeadTimeStateFromModel();
         this.syncTimeMenus();
+        if (hasBufferConfig(newBookable)) {
+          this.bufferExpanded = true;
+        }
       }
     },
   },
@@ -110,6 +141,34 @@ export default {
     applyPreset(minutes) {
       this.model.preparationLeadTimeMinutes = minutes;
       this.emitUpdate();
+    },
+    displayBufferMinutes(value) {
+      return value == null || value === "" ? "" : value;
+    },
+    setBufferMinutes(field, value) {
+      if (value === "" || value == null) {
+        this.model[field] = null;
+      } else {
+        const minutes = Number(value);
+        this.model[field] =
+          Number.isFinite(minutes) && minutes > 0 ? Math.floor(minutes) : null;
+      }
+      this.emitUpdate();
+    },
+    applyBufferPreset(field, minutes) {
+      this.model[field] = minutes > 0 ? minutes : null;
+      this.emitUpdate();
+    },
+    isBufferMinutesValid(value) {
+      if (value == null || value === "") {
+        return true;
+      }
+      const minutes = Number(value);
+      return Number.isFinite(minutes) && minutes >= 0 && Number.isInteger(minutes);
+    },
+    bufferPresetActive(field, minutes) {
+      const current = Number(this.model[field]) || 0;
+      return current === minutes;
     },
     addServiceHours() {
       const index = this.model.serviceHours.length;
@@ -174,15 +233,20 @@ export default {
       return this.expandedItems.includes(index);
     },
     async validate() {
-      if (!this.model.isLeadTimeRelated) {
-        return true;
-      }
       const formValid = this.$refs.form ? this.$refs.form.validate() : true;
       if (!formValid) {
         return false;
       }
+      if (!this.model.isLeadTimeRelated) {
+        return (
+          this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
+          this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes)
+        );
+      }
       return (
         this.isPreparationMinutesValid() &&
+        this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
+        this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes) &&
         this.model.serviceHours.length > 0 &&
         this.model.serviceHours.every(
           (entry) =>
@@ -499,6 +563,138 @@ export default {
             </v-btn>
           </div>
         </template>
+
+        <v-divider class="my-4" />
+
+        <div
+          class="buffer-section-header d-flex align-center"
+          role="button"
+          tabindex="0"
+          @click="bufferExpanded = !bufferExpanded"
+          @keydown.enter.prevent="bufferExpanded = !bufferExpanded"
+          @keydown.space.prevent="bufferExpanded = !bufferExpanded"
+        >
+          <v-icon class="mr-2" small>mdi-calendar-remove-outline</v-icon>
+          <div class="flex-grow-1">
+            <div class="text-subtitle-2">Kapazitäts-Puffer</div>
+            <div class="text-caption text--secondary">
+              {{ bufferSummary }}
+            </div>
+          </div>
+          <v-chip
+            v-if="bufferEnabled"
+            x-small
+            color="primary"
+            text-color="white"
+            class="mr-2"
+          >
+            Aktiv
+          </v-chip>
+          <v-icon small>
+            {{ bufferExpanded ? "mdi-chevron-up" : "mdi-chevron-down" }}
+          </v-icon>
+        </div>
+
+        <v-expand-transition>
+          <div v-show="bufferExpanded" class="mt-3">
+            <v-alert color="grey" dense text class="mb-4 caption">
+              Verhindert direkt aufeinanderfolgende Buchungen. Gilt nicht bei
+              manueller Buchung mit Berechtigung.
+            </v-alert>
+
+            <v-row dense>
+              <v-col cols="12" md="6">
+                <div class="text-caption font-weight-medium mb-1">
+                  Puffer vor Buchung
+                </div>
+                <div class="text-caption text--secondary mb-2">
+                  z. B. Reinigung oder Vorbereitung vor dem Termin
+                </div>
+                <v-text-field
+                  background-color="accent"
+                  filled
+                  dense
+                  label="Dauer"
+                  type="number"
+                  min="0"
+                  suffix="Minuten"
+                  :value="displayBufferMinutes(model.bufferTimeBeforeMinutes)"
+                  hide-details="auto"
+                  :rules="[
+                    (v) =>
+                      isBufferMinutesValid(v) ||
+                      'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
+                  ]"
+                  @input="setBufferMinutes('bufferTimeBeforeMinutes', $event)"
+                />
+                <div class="d-flex flex-wrap mt-2">
+                  <v-chip
+                    v-for="preset in bufferPresets"
+                    :key="`before-${preset.value}`"
+                    x-small
+                    class="mr-1 mb-1"
+                    :color="
+                      bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
+                        ? 'primary'
+                        : undefined
+                    "
+                    :outlined="
+                      !bufferPresetActive('bufferTimeBeforeMinutes', preset.value)
+                    "
+                    @click="applyBufferPreset('bufferTimeBeforeMinutes', preset.value)"
+                  >
+                    {{ preset.label }}
+                  </v-chip>
+                </div>
+              </v-col>
+
+              <v-col cols="12" md="6">
+                <div class="text-caption font-weight-medium mb-1">
+                  Puffer nach Buchung
+                </div>
+                <div class="text-caption text--secondary mb-2">
+                  z. B. Nachbereitung oder Umräumen
+                </div>
+                <v-text-field
+                  background-color="accent"
+                  filled
+                  dense
+                  label="Dauer"
+                  type="number"
+                  min="0"
+                  suffix="Minuten"
+                  :value="displayBufferMinutes(model.bufferTimeAfterMinutes)"
+                  hide-details="auto"
+                  :rules="[
+                    (v) =>
+                      isBufferMinutesValid(v) ||
+                      'Gültige Dauer erforderlich (0 oder positive Ganzzahl)',
+                  ]"
+                  @input="setBufferMinutes('bufferTimeAfterMinutes', $event)"
+                />
+                <div class="d-flex flex-wrap mt-2">
+                  <v-chip
+                    v-for="preset in bufferPresets"
+                    :key="`after-${preset.value}`"
+                    x-small
+                    class="mr-1 mb-1"
+                    :color="
+                      bufferPresetActive('bufferTimeAfterMinutes', preset.value)
+                        ? 'primary'
+                        : undefined
+                    "
+                    :outlined="
+                      !bufferPresetActive('bufferTimeAfterMinutes', preset.value)
+                    "
+                    @click="applyBufferPreset('bufferTimeAfterMinutes', preset.value)"
+                  >
+                    {{ preset.label }}
+                  </v-chip>
+                </div>
+              </v-col>
+            </v-row>
+          </div>
+        </v-expand-transition>
       </v-card-text>
     </v-card>
   </v-form>
@@ -523,6 +719,24 @@ export default {
     rgba(255, 255, 255, 0.05) 0%,
     rgba(255, 255, 255, 0.02) 100%
   );
+}
+
+.buffer-section-header {
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 8px 4px;
+  transition: background-color 0.2s ease;
+}
+
+.buffer-section-header:hover,
+.buffer-section-header:focus {
+  background-color: rgba(0, 0, 0, 0.04);
+  outline: none;
+}
+
+.theme--dark .buffer-section-header:hover,
+.theme--dark .buffer-section-header:focus {
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
 .service-hours-item {

--- a/src/components/Booking/BookingEdit.vue
+++ b/src/components/Booking/BookingEdit.vue
@@ -1096,14 +1096,14 @@ export default {
       const hasBuffer = this.hasBufferBookables;
       if (hasLeadTime && hasBuffer) {
         return (
-          "Mindestens ein Buchungsobjekt hat Vorlaufzeit und/oder Kapazitäts-Puffer " +
+          "Mindestens ein Buchungsobjekt hat Vorlaufzeit und/oder Puffer zwischen Buchungen " +
           "konfiguriert. Bei manuellen Buchungen werden diese Regeln nicht geprüft – " +
           "sie gelten nur im öffentlichen Checkout."
         );
       }
       if (hasBuffer) {
         return (
-          "Mindestens ein Buchungsobjekt hat einen Kapazitäts-Puffer konfiguriert. " +
+          "Mindestens ein Buchungsobjekt hat einen Puffer zwischen Buchungen konfiguriert. " +
           "Bei manuellen Buchungen wird diese Regel nicht geprüft – sie gilt nur im " +
           "öffentlichen Checkout."
         );

--- a/src/components/Booking/BookingEdit.vue
+++ b/src/components/Booking/BookingEdit.vue
@@ -279,15 +279,13 @@
             </v-alert>
 
             <v-alert
-              v-if="hasLeadTimeBookables"
+              v-if="hasCheckoutAvailabilityRestrictions"
               type="info"
               dense
               text
               class="mt-3 mb-0 caption"
             >
-              Mindestens ein Buchungsobjekt hat eine Vorlaufzeit konfiguriert.
-              Bei manuellen Buchungen wird diese Regel nicht geprüft – sie gilt
-              nur im öffentlichen Checkout.
+              {{ checkoutAvailabilityRestrictionHint }}
             </v-alert>
 
             <div class="d-flex align-center justify-space-between mt-4 mb-1">
@@ -872,7 +870,7 @@ import CheckoutCalendar from "@/components/Checkout/CheckoutCalendar.vue";
 import { getTypeColor, getTypeIcon, getTypeText } from "@/utils/bookables";
 import { isTimeDependentBookable } from "@/utils/bookableBookingMode";
 import { formatCheckoutValidationError } from "@/utils/checkoutErrors";
-import { hasLeadTimeConfig } from "@/utils/bookingLeadTime";
+import { hasBufferConfig, hasLeadTimeConfig } from "@/utils/bookingLeadTime";
 import {
   resolveBookingCheckoutCustomFields,
   setCustomFieldValue,
@@ -1083,6 +1081,37 @@ export default {
     hasLeadTimeBookables() {
       return this.bookableItems.some((item) =>
         hasLeadTimeConfig(item._bookableUsed)
+      );
+    },
+    hasBufferBookables() {
+      return this.bookableItems.some((item) =>
+        hasBufferConfig(item._bookableUsed)
+      );
+    },
+    hasCheckoutAvailabilityRestrictions() {
+      return this.hasLeadTimeBookables || this.hasBufferBookables;
+    },
+    checkoutAvailabilityRestrictionHint() {
+      const hasLeadTime = this.hasLeadTimeBookables;
+      const hasBuffer = this.hasBufferBookables;
+      if (hasLeadTime && hasBuffer) {
+        return (
+          "Mindestens ein Buchungsobjekt hat Vorlaufzeit und/oder Kapazitäts-Puffer " +
+          "konfiguriert. Bei manuellen Buchungen werden diese Regeln nicht geprüft – " +
+          "sie gelten nur im öffentlichen Checkout."
+        );
+      }
+      if (hasBuffer) {
+        return (
+          "Mindestens ein Buchungsobjekt hat einen Kapazitäts-Puffer konfiguriert. " +
+          "Bei manuellen Buchungen wird diese Regel nicht geprüft – sie gilt nur im " +
+          "öffentlichen Checkout."
+        );
+      }
+      return (
+        "Mindestens ein Buchungsobjekt hat eine Vorlaufzeit konfiguriert. " +
+        "Bei manuellen Buchungen wird diese Regel nicht geprüft – sie gilt nur im " +
+        "öffentlichen Checkout."
       );
     },
     hasUnsavedChanges() {

--- a/src/entities/bookable.js
+++ b/src/entities/bookable.js
@@ -35,6 +35,7 @@ export default class Bookable {
     this.isLeadTimeRelated = false;
     this.preparationLeadTimeMinutes = 0;
     this.serviceHours = [];
+    this.isBufferRelated = false;
     this.bufferTimeBeforeMinutes = null;
     this.bufferTimeAfterMinutes = null;
 

--- a/src/entities/bookable.js
+++ b/src/entities/bookable.js
@@ -35,6 +35,8 @@ export default class Bookable {
     this.isLeadTimeRelated = false;
     this.preparationLeadTimeMinutes = 0;
     this.serviceHours = [];
+    this.bufferTimeBeforeMinutes = null;
+    this.bufferTimeAfterMinutes = null;
 
     this.priceCategories = [
       {

--- a/src/store/modules/bookables.js
+++ b/src/store/modules/bookables.js
@@ -40,6 +40,7 @@ const state = {
     isLeadTimeRelated: false,
     preparationLeadTimeMinutes: 0,
     serviceHours: [],
+    isBufferRelated: false,
     bufferTimeBeforeMinutes: null,
     bufferTimeAfterMinutes: null,
 
@@ -141,6 +142,7 @@ const mutations = {
       isLeadTimeRelated: false,
       preparationLeadTimeMinutes: 0,
       serviceHours: [],
+      isBufferRelated: false,
       bufferTimeBeforeMinutes: null,
       bufferTimeAfterMinutes: null,
 

--- a/src/store/modules/bookables.js
+++ b/src/store/modules/bookables.js
@@ -40,6 +40,8 @@ const state = {
     isLeadTimeRelated: false,
     preparationLeadTimeMinutes: 0,
     serviceHours: [],
+    bufferTimeBeforeMinutes: null,
+    bufferTimeAfterMinutes: null,
 
     priceCategories: [
       {
@@ -139,6 +141,8 @@ const mutations = {
       isLeadTimeRelated: false,
       preparationLeadTimeMinutes: 0,
       serviceHours: [],
+      bufferTimeBeforeMinutes: null,
+      bufferTimeAfterMinutes: null,
 
       priceCategories: [
         {

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -18,6 +18,29 @@ export function hasLeadTimeConfig(bookable) {
   );
 }
 
+export function hasBufferConfig(bookable) {
+  if (!bookable?.isScheduleRelated) {
+    return false;
+  }
+  const before = Number(bookable.bufferTimeBeforeMinutes);
+  const after = Number(bookable.bufferTimeAfterMinutes);
+  return (
+    (Number.isFinite(before) && before > 0) ||
+    (Number.isFinite(after) && after > 0)
+  );
+}
+
+function normalizeBufferMinutes(value) {
+  if (value == null || value === "") {
+    return null;
+  }
+  const minutes = Number(value);
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return null;
+  }
+  return Math.floor(minutes);
+}
+
 export function normalizeLeadTimeFields(bookable) {
   if (!bookable) {
     return bookable;
@@ -32,8 +55,17 @@ export function normalizeLeadTimeFields(bookable) {
 
   if (!bookable.isScheduleRelated) {
     bookable.isLeadTimeRelated = false;
+    bookable.bufferTimeBeforeMinutes = null;
+    bookable.bufferTimeAfterMinutes = null;
     return bookable;
   }
+
+  bookable.bufferTimeBeforeMinutes = normalizeBufferMinutes(
+    bookable.bufferTimeBeforeMinutes
+  );
+  bookable.bufferTimeAfterMinutes = normalizeBufferMinutes(
+    bookable.bufferTimeAfterMinutes
+  );
 
   const hasExistingLeadTimeConfig = hasLeadTimeConfig(bookable);
   const hasServiceHours = bookable.serviceHours.length > 0;

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -79,7 +79,7 @@ export function normalizeLeadTimeFields(bookable) {
 
   if (hasBufferConfig(bookable)) {
     bookable.isBufferRelated = true;
-  } else if (bookable.isBufferRelated == null) {
+  } else {
     bookable.isBufferRelated = false;
   }
 

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -55,6 +55,7 @@ export function normalizeLeadTimeFields(bookable) {
 
   if (!bookable.isScheduleRelated) {
     bookable.isLeadTimeRelated = false;
+    bookable.isBufferRelated = false;
     bookable.bufferTimeBeforeMinutes = null;
     bookable.bufferTimeAfterMinutes = null;
     return bookable;
@@ -74,6 +75,12 @@ export function normalizeLeadTimeFields(bookable) {
     bookable.isLeadTimeRelated = true;
   } else if (bookable.isLeadTimeRelated == null) {
     bookable.isLeadTimeRelated = false;
+  }
+
+  if (hasBufferConfig(bookable)) {
+    bookable.isBufferRelated = true;
+  } else if (bookable.isBufferRelated == null) {
+    bookable.isBufferRelated = false;
   }
 
   return bookable;


### PR DESCRIPTION
## Summary
- Extends `BookableEditLeadTime.vue` with configurable before/after booking gap buffers (`bufferTimeBeforeMinutes`, `bufferTimeAfterMinutes`) in a separate card with enable switch and presets (None / 15 / 30 min)
- Adds `isBufferRelated` UI flag plus entity/store defaults and normalization in `bookingLeadTime.js` (`hasBufferConfig`, `0`/empty → inactive)
- Updates the manual booking hint in `BookingEdit.vue` for lead time and/or booking gap restrictions

## Test plan
- [ ] Open a bookable with free time selection → Booking type tab → enable “Gap between bookings” card
- [ ] Set before/after buffers (e.g. 30 min after), save, reload → values persist
- [ ] `0` or “None” → backend field inactive (`null`)
- [ ] Lead time editor (Phase 1) still works without regression
- [ ] Manual booking with gap-configured object → info hint visible
- [ ] Public checkout blocks slots per backend Phase 2 (#206)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added “buffer between bookings” support to the lead-time editor, including before/after buffer minutes, preset chips, and an enable/disable switch.

* **Bug Fixes**
  * Updated validation and normalization for buffer minutes, ensuring invalid/empty or non-positive inputs are cleared and buffer settings toggle reliably.
  * Improved checkout availability warnings to account for lead-time and buffer-based restrictions, with context-specific messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->