### PR TITLE
fix(DEV-776): Kostenfreie Buchungen als „Kostenfrei“ kennzeichnen

### DIFF
--- a/src/components/Booking/BookingDetails.vue
+++ b/src/components/Booking/BookingDetails.vue
@@ -380,7 +380,7 @@
                     <v-chip
                       small
                       :color="getPaymentStatusColor(booking)"
-                      text-color="white"
+                      :text-color="getPaymentStatusTextColor(booking)"
                     >
                       <v-icon left x-small>
                         {{ getPaymentStatusIcon(booking) }}
@@ -1067,6 +1067,7 @@ import {
   getPaymentStatusColor,
   getPaymentStatusIcon,
   getPaymentStatusLabel,
+  getPaymentStatusTextColor,
   PAYMENT_STATUS,
 } from "@/utils/bookingPaymentStatus";
 
@@ -1182,6 +1183,7 @@ export default {
     getPaymentStatusLabel,
     getPaymentStatusColor,
     getPaymentStatusIcon,
+    getPaymentStatusTextColor,
     isPaymentPending(booking) {
       return getPaymentStatus(booking) === PAYMENT_STATUS.UNPAID;
     },

--- a/src/components/Booking/BookingDetails.vue
+++ b/src/components/Booking/BookingDetails.vue
@@ -379,15 +379,13 @@
                   <div class="info-value">
                     <v-chip
                       small
-                      :color="booking.isPayed ? 'success' : 'warning'"
+                      :color="getPaymentStatusColor(booking)"
                       text-color="white"
                     >
                       <v-icon left x-small>
-                        {{
-                          booking.isPayed ? "mdi-check" : "mdi-clock-outline"
-                        }}
+                        {{ getPaymentStatusIcon(booking) }}
                       </v-icon>
-                      {{ booking.isPayed ? "Bezahlt" : "Ausstehend" }}
+                      {{ getPaymentStatusLabel(booking) }}
                     </v-chip>
                   </div>
                 </div>
@@ -419,7 +417,7 @@
               <v-col
                 cols="12"
                 v-if="
-                  !booking.isPayed &&
+                  isPaymentPending(booking) &&
                   booking.isCommitted &&
                   booking.paymentProvider &&
                   booking.paymentProvider !== 'invoice'
@@ -536,7 +534,7 @@
               <v-col
                 cols="12"
                 md="6"
-                v-if="booking.isPayed && booking.timePaid"
+                v-if="hasPaidDate(booking)"
               >
                 <div class="info-item">
                   <div class="info-label">
@@ -1064,6 +1062,13 @@ import { getIfbsErrorMessage } from "@/utils/ifbsErrors";
 import ProcessingIndicator from "@/components/ProcessingIndicator.vue";
 import ProcessingService from "@/services/ProcessingService";
 import BookableTypeChip from "@/components/commons/BookableTypeChip.vue";
+import {
+  getPaymentStatus,
+  getPaymentStatusColor,
+  getPaymentStatusIcon,
+  getPaymentStatusLabel,
+  PAYMENT_STATUS,
+} from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "BookingDetails",
@@ -1173,6 +1178,18 @@ export default {
       startLoading: "loading/start",
       stopLoading: "loading/stop",
     }),
+    getPaymentStatus,
+    getPaymentStatusLabel,
+    getPaymentStatusColor,
+    getPaymentStatusIcon,
+    isPaymentPending(booking) {
+      return getPaymentStatus(booking) === PAYMENT_STATUS.UNPAID;
+    },
+    hasPaidDate(booking) {
+      return (
+        getPaymentStatus(booking) === PAYMENT_STATUS.PAID && booking.timePaid
+      );
+    },
 
     async generateAndSendInvoice() {
       this.invoiceLoading = true;

--- a/src/components/Booking/BookingExportButton.vue
+++ b/src/components/Booking/BookingExportButton.vue
@@ -5,6 +5,7 @@ import { mapActions } from "vuex";
 import ApiBookingService from "@/services/api/ApiBookingService";
 import ProcessingService from "@/services/ProcessingService";
 import ToastService from "@/services/ToastService";
+import { getPaymentStatusExportValue } from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "BookingExportButton",
@@ -60,7 +61,7 @@ export default {
         { header: "Grundpreis (brutto in EUR)", key: "regularPreis", width: 15 },
         { header: "Grund-MwSt (EUR)", key: "regularMwSt", width: 15 },
 
-        { header: "Bezahlt", key: "Bezahlt", width: 12 },
+        { header: "Zahlungsstatus", key: "Bezahlt", width: 14 },
         { header: "Payment Provider", key: "PaymentProvider", width: 15 },
         { header: "Payment Method", key: "PaymentMethod", width: 15 },
 
@@ -117,7 +118,7 @@ export default {
           regularPreis: this.getRegularGrossPriceSum(booking) || 0,
           regularMwSt: this.getRegularVatIncludedSum(booking) || 0,
 
-          Bezahlt: booking.isPayed ? "Ja" : "Nein",
+          Bezahlt: getPaymentStatusExportValue(booking),
           PaymentProvider: booking.PaymentProvider || "",
           PaymentMethod: this.getPaymentMethod(booking.paymentMethod) || "",
 

--- a/src/components/Booking/BookingKanbanCard.vue
+++ b/src/components/Booking/BookingKanbanCard.vue
@@ -97,7 +97,7 @@
           v-if="showPaymentStatusChip"
           x-small
           :color="getPaymentStatusColor(element.bookingItem)"
-          text-color="white"
+          :text-color="getPaymentStatusTextColor(element.bookingItem)"
         >
           <v-icon x-small left>{{
             getPaymentStatusIcon(element.bookingItem)
@@ -135,6 +135,7 @@ import {
   getPaymentStatusColor,
   getPaymentStatusIcon,
   getPaymentStatusLabel,
+  getPaymentStatusTextColor,
   PAYMENT_STATUS,
 } from "@/utils/bookingPaymentStatus";
 
@@ -185,6 +186,7 @@ export default {
     getPaymentStatusLabel,
     getPaymentStatusColor,
     getPaymentStatusIcon,
+    getPaymentStatusTextColor,
     onOpenBooking(bookingId) {
       this.$emit("open-booking", bookingId);
     },

--- a/src/components/Booking/BookingKanbanCard.vue
+++ b/src/components/Booking/BookingKanbanCard.vue
@@ -94,13 +94,15 @@
     <div class="d-flex align-center justify-space-between px-2 pb-2">
       <div class="d-flex align-center flex-wrap" style="gap: 4px">
         <v-chip
-          v-if="element.bookingItem?.isPayed"
+          v-if="showPaymentStatusChip"
           x-small
-          color="success"
+          :color="getPaymentStatusColor(element.bookingItem)"
           text-color="white"
         >
-          <v-icon x-small left>mdi-check</v-icon>
-          Bezahlt
+          <v-icon x-small left>{{
+            getPaymentStatusIcon(element.bookingItem)
+          }}</v-icon>
+          {{ getPaymentStatusLabel(element.bookingItem) }}
         </v-chip>
 
         <v-chip
@@ -128,6 +130,14 @@
 
 <script>
 import BookingRejectConformationDialog from "@/components/Booking/BookingRejectConformationDialog.vue";
+import {
+  getPaymentStatus,
+  getPaymentStatusColor,
+  getPaymentStatusIcon,
+  getPaymentStatusLabel,
+  PAYMENT_STATUS,
+} from "@/utils/bookingPaymentStatus";
+
 export default {
   name: "BookingKanbanCard",
   components: { BookingRejectConformationDialog },
@@ -165,8 +175,16 @@ export default {
       if (days >= 2) return "duration--warning";
       return "duration--ok";
     },
+    showPaymentStatusChip() {
+      const booking = this.element.bookingItem;
+      if (!booking) return false;
+      return getPaymentStatus(booking) !== PAYMENT_STATUS.UNPAID;
+    },
   },
   methods: {
+    getPaymentStatusLabel,
+    getPaymentStatusColor,
+    getPaymentStatusIcon,
     onOpenBooking(bookingId) {
       this.$emit("open-booking", bookingId);
     },

--- a/src/components/Booking/BookingTable.vue
+++ b/src/components/Booking/BookingTable.vue
@@ -299,6 +299,7 @@ import {
   getPaymentStatusColor,
   getPaymentStatusIcon,
   getPaymentStatusLabel,
+  getPaymentStatusTextColor,
   isFreeBooking,
 } from "@/utils/bookingPaymentStatus";
 
@@ -348,8 +349,8 @@ export default {
       return this.showGroupBooking
         ? this.defaultHeaders
         : this.defaultHeaders.filter(
-            (header) => header.value !== "groupBooking"
-          );
+          (header) => header.value !== "groupBooking"
+        );
     },
   },
   methods: {
@@ -388,8 +389,8 @@ export default {
     getPaymentColor(item) {
       return getPaymentStatusColor(item);
     },
-    getPaymentTextColor() {
-      return "white";
+    getPaymentTextColor(item) {
+      return getPaymentStatusTextColor(item);
     },
     getPaymentIcon(item) {
       return getPaymentStatusIcon(item);

--- a/src/components/Booking/BookingTable.vue
+++ b/src/components/Booking/BookingTable.vue
@@ -295,6 +295,12 @@
 
 <script>
 import BookingPermissionService from "@/services/permissions/BookingPermissionService";
+import {
+  getPaymentStatusColor,
+  getPaymentStatusIcon,
+  getPaymentStatusLabel,
+  isFreeBooking,
+} from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "BookingTable",
@@ -378,19 +384,18 @@ export default {
       if (item.isCommitted) return "Freigegeben";
       return "Ausstehend";
     },
+    isFreeBooking,
     getPaymentColor(item) {
-      if (item.priceEur <= 0) return "grey lighten-1";
-      return item.isPayed ? "success" : "grey";
+      return getPaymentStatusColor(item);
     },
-    getPaymentTextColor(item) {
+    getPaymentTextColor() {
       return "white";
     },
     getPaymentIcon(item) {
-      if (item.priceEur <= 0) return "mdi-gift";
-      return item.isPayed ? "mdi-check-circle" : "mdi-clock-outline";
+      return getPaymentStatusIcon(item);
     },
-    hasEventId(item){
-      return item.bookableItems.some(b => b._bookableUsed.eventId);
+    hasEventId(item) {
+      return item.bookableItems.some((b) => b._bookableUsed.eventId);
     },
     formatCurrency(amount) {
       return Intl.NumberFormat("de-DE", {
@@ -399,10 +404,7 @@ export default {
       }).format(amount || 0);
     },
     payedStatus(item) {
-      if (item.isPayed && item.priceEur > 0) return "Bezahlt";
-      if (!item.isPayed && item.priceEur > 0) return "Offen";
-      if (item.priceEur <= 0) return "Kostenlos";
-      return "N/A";
+      return getPaymentStatusLabel(item);
     },
     translatePayMethod(paymentMethod) {
       const methods = {
@@ -444,7 +446,7 @@ export default {
     onOpenGroupBooking(groupBookingId) {
       this.$emit("open-group-booking", groupBookingId);
     },
-    onDownloadIcal(bookingId){
+    onDownloadIcal(bookingId) {
       this.$emit("download-ical", bookingId);
     },
     commitBooking(bookingId) {
@@ -461,7 +463,6 @@ export default {
 </script>
 
 <style scoped>
-
 .booking-table-wrapper {
   position: relative;
   border-radius: 25px;

--- a/src/js-web-interface/booking-manager-js.js
+++ b/src/js-web-interface/booking-manager-js.js
@@ -24,6 +24,24 @@
  *   });
  * </script>
  */
+// Mirrors src/utils/bookingPaymentStatus.js for the standalone CDN bundle.
+function bmIsFreeBooking(booking) {
+  if (booking?.priceEur == null) {
+    return false;
+  }
+  return Number(booking.priceEur) <= 0;
+}
+
+function bmGetPaymentStatusLabel(booking) {
+  if (bmIsFreeBooking(booking)) {
+    return "Kostenfrei";
+  }
+  if (booking.isPayed) {
+    return "Bezahlt";
+  }
+  return "Offen";
+}
+
 // eslint-disable-next-line no-unused-vars
 class BookingManager {
   /**
@@ -732,13 +750,7 @@ class BookingManager {
             const commitLabel = booking.isCommitted
               ? "Freigegeben"
               : "Nicht freigegeben";
-            const paymentLabel =
-              (booking.priceEur ?? 0) <= 0
-                ? "Kostenfrei"
-                : booking.isPayed
-                  ? "Bezahlt"
-                  : "Nicht bezahlt";
-            booking.status = `${commitLabel} / ${paymentLabel}`;
+            booking.status = `${commitLabel} / ${bmGetPaymentStatusLabel(booking)}`;
             booking.title = booking.bookable.map((bookable) => {
               return bookable._bookableUsed.title;
             });
@@ -969,9 +981,9 @@ class BookingManager {
         const formatTime = (date) => {
           return date
             ? date.toLocaleTimeString("de-DE", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })
+              hour: "2-digit",
+              minute: "2-digit",
+            })
             : "";
         };
 

--- a/src/js-web-interface/booking-manager-js.js
+++ b/src/js-web-interface/booking-manager-js.js
@@ -725,18 +725,20 @@ class BookingManager {
               ),
               isCommitted: booking.isCommitted,
               isPayed: booking.isPayed,
+              priceEur: booking.priceEur,
             };
           });
           bookings.forEach((booking) => {
-            if (booking.isPayed && booking.isCommitted) {
-              booking.status = "Freigegeben / Bezahlt";
-            } else if (booking.isPayed && !booking.isCommitted) {
-              booking.status = "Nicht freigegeben / Bezahlt";
-            } else if (!booking.isPayed && booking.isCommitted) {
-              booking.status = "Freigegeben / Nicht bezahlt";
-            } else {
-              booking.status = "Nicht freigegeben / Nicht bezahlt";
-            }
+            const commitLabel = booking.isCommitted
+              ? "Freigegeben"
+              : "Nicht freigegeben";
+            const paymentLabel =
+              (booking.priceEur ?? 0) <= 0
+                ? "Kostenfrei"
+                : booking.isPayed
+                  ? "Bezahlt"
+                  : "Nicht bezahlt";
+            booking.status = `${commitLabel} / ${paymentLabel}`;
             booking.title = booking.bookable.map((bookable) => {
               return bookable._bookableUsed.title;
             });

--- a/src/utils/bookingPaymentStatus.js
+++ b/src/utils/bookingPaymentStatus.js
@@ -1,0 +1,96 @@
+export const PAYMENT_STATUS = {
+  FREE: "free",
+  PAID: "paid",
+  UNPAID: "unpaid",
+};
+
+export function isFreeBooking(booking) {
+  const price = Number(booking?.priceEur ?? booking?.totalPrice ?? 0);
+  return price <= 0;
+}
+
+export function getPaymentStatus(booking) {
+  if (isFreeBooking(booking)) {
+    return PAYMENT_STATUS.FREE;
+  }
+  if (booking?.isPayed) {
+    return PAYMENT_STATUS.PAID;
+  }
+  return PAYMENT_STATUS.UNPAID;
+}
+
+export function getPaymentStatusLabel(booking) {
+  switch (getPaymentStatus(booking)) {
+    case PAYMENT_STATUS.FREE:
+      return "Kostenfrei";
+    case PAYMENT_STATUS.PAID:
+      return "Bezahlt";
+    default:
+      return "Offen";
+  }
+}
+
+export function getPaymentStatusColor(booking) {
+  switch (getPaymentStatus(booking)) {
+    case PAYMENT_STATUS.FREE:
+      return "grey lighten-1";
+    case PAYMENT_STATUS.PAID:
+      return "success";
+    default:
+      return "grey";
+  }
+}
+
+export function getPaymentStatusIcon(booking) {
+  switch (getPaymentStatus(booking)) {
+    case PAYMENT_STATUS.FREE:
+      return "mdi-gift";
+    case PAYMENT_STATUS.PAID:
+      return "mdi-check-circle";
+    default:
+      return "mdi-clock-outline";
+  }
+}
+
+export function getPublicPaymentStatusLabel(status, priceEur) {
+  if (Number(priceEur ?? 0) <= 0) {
+    return "Kostenfrei";
+  }
+  if (status?.paymentStatus === "paid") {
+    return "Bezahlt";
+  }
+  return "Zahlung ausstehend";
+}
+
+export function isBookingFullyComplete(booking) {
+  if (!booking?.isCommitted) {
+    return false;
+  }
+  return getPaymentStatus(booking) !== PAYMENT_STATUS.UNPAID;
+}
+
+export function getPaymentStatusExportValue(booking) {
+  switch (getPaymentStatus(booking)) {
+    case PAYMENT_STATUS.FREE:
+      return "Kostenfrei";
+    case PAYMENT_STATUS.PAID:
+      return "Ja";
+    default:
+      return "Nein";
+  }
+}
+
+export function getCombinedStatusText(booking) {
+  const commitLabel = booking.isCommitted
+    ? "Freigegeben"
+    : "Nicht freigegeben";
+  const paymentLabel = getPaymentStatusLabel(booking);
+  return `${commitLabel} / ${paymentLabel}`;
+}
+
+export function isCheckoutStatusComplete(booking) {
+  if (!booking?.isCommitted) {
+    return false;
+  }
+  return isFreeBooking(booking) || booking.isPayed;
+}

--- a/src/utils/bookingPaymentStatus.js
+++ b/src/utils/bookingPaymentStatus.js
@@ -5,8 +5,10 @@ export const PAYMENT_STATUS = {
 };
 
 export function isFreeBooking(booking) {
-  const price = Number(booking?.priceEur ?? booking?.totalPrice ?? 0);
-  return price <= 0;
+  if (booking?.priceEur == null) {
+    return false;
+  }
+  return Number(booking.priceEur) <= 0;
 }
 
 export function getPaymentStatus(booking) {
@@ -21,39 +23,45 @@ export function getPaymentStatus(booking) {
 
 export function getPaymentStatusLabel(booking) {
   switch (getPaymentStatus(booking)) {
-    case PAYMENT_STATUS.FREE:
-      return "Kostenfrei";
-    case PAYMENT_STATUS.PAID:
-      return "Bezahlt";
-    default:
-      return "Offen";
+  case PAYMENT_STATUS.FREE:
+    return "Kostenfrei";
+  case PAYMENT_STATUS.PAID:
+    return "Bezahlt";
+  default:
+    return "Offen";
   }
 }
 
 export function getPaymentStatusColor(booking) {
   switch (getPaymentStatus(booking)) {
-    case PAYMENT_STATUS.FREE:
-      return "grey lighten-1";
-    case PAYMENT_STATUS.PAID:
-      return "success";
-    default:
-      return "grey";
+  case PAYMENT_STATUS.FREE:
+    return "grey lighten-1";
+  case PAYMENT_STATUS.PAID:
+    return "success";
+  default:
+    return "grey";
   }
+}
+
+export function getPaymentStatusTextColor(booking) {
+  return getPaymentStatus(booking) === PAYMENT_STATUS.FREE
+    ? "grey darken-3"
+    : "white";
 }
 
 export function getPaymentStatusIcon(booking) {
   switch (getPaymentStatus(booking)) {
-    case PAYMENT_STATUS.FREE:
-      return "mdi-gift";
-    case PAYMENT_STATUS.PAID:
-      return "mdi-check-circle";
-    default:
-      return "mdi-clock-outline";
+  case PAYMENT_STATUS.FREE:
+    return "mdi-gift";
+  case PAYMENT_STATUS.PAID:
+    return "mdi-check-circle";
+  default:
+    return "mdi-clock-outline";
   }
 }
 
 export function getPublicPaymentStatusLabel(status, priceEur) {
-  if (Number(priceEur ?? 0) <= 0) {
+  if (isFreeBooking({ priceEur })) {
     return "Kostenfrei";
   }
   if (status?.paymentStatus === "paid") {
@@ -69,14 +77,18 @@ export function isBookingFullyComplete(booking) {
   return getPaymentStatus(booking) !== PAYMENT_STATUS.UNPAID;
 }
 
+export function isCheckoutStatusComplete(booking) {
+  return isBookingFullyComplete(booking);
+}
+
 export function getPaymentStatusExportValue(booking) {
   switch (getPaymentStatus(booking)) {
-    case PAYMENT_STATUS.FREE:
-      return "Kostenfrei";
-    case PAYMENT_STATUS.PAID:
-      return "Ja";
-    default:
-      return "Nein";
+  case PAYMENT_STATUS.FREE:
+    return "Kostenfrei";
+  case PAYMENT_STATUS.PAID:
+    return "Ja";
+  default:
+    return "Nein";
   }
 }
 
@@ -86,11 +98,4 @@ export function getCombinedStatusText(booking) {
     : "Nicht freigegeben";
   const paymentLabel = getPaymentStatusLabel(booking);
   return `${commitLabel} / ${paymentLabel}`;
-}
-
-export function isCheckoutStatusComplete(booking) {
-  if (!booking?.isCommitted) {
-    return false;
-  }
-  return isFreeBooking(booking) || booking.isPayed;
 }

--- a/src/views/BookingStatus.vue
+++ b/src/views/BookingStatus.vue
@@ -200,8 +200,8 @@
 
           <v-chip
             class="ma-2"
-            color="grey lighten-1"
-            text-color="white"
+            :color="getPaymentStatusColor(bookingInfo)"
+            :text-color="getPaymentStatusTextColor(bookingInfo)"
             v-if="isFreeBooking(bookingInfo)"
           >
             <v-icon left>mdi-gift</v-icon>
@@ -277,7 +277,7 @@
 <script>
 import ApiBookingService from "@/services/api/ApiBookingService";
 import FormatService from "@/services/FormatService";
-import { isFreeBooking } from "@/utils/bookingPaymentStatus";
+import { isFreeBooking, getPaymentStatusColor, getPaymentStatusTextColor } from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "BookingStatus",
@@ -327,6 +327,8 @@ export default {
   },
   methods: {
     isFreeBooking,
+    getPaymentStatusColor,
+    getPaymentStatusTextColor,
     submitForm() {
       if (this.$refs.form.validate()) {
         this.fetchBookingStatus();

--- a/src/views/BookingStatus.vue
+++ b/src/views/BookingStatus.vue
@@ -200,15 +200,30 @@
 
           <v-chip
             class="ma-2"
+            color="grey lighten-1"
+            text-color="white"
+            v-if="isFreeBooking(bookingInfo)"
+          >
+            <v-icon left>mdi-gift</v-icon>
+            Kostenfrei
+          </v-chip>
+
+          <v-chip
+            class="ma-2"
             color="green"
             text-color="white"
-            v-if="bookingInfo.status.paymentStatus === 'paid'"
+            v-else-if="bookingInfo.status.paymentStatus === 'paid'"
           >
             <v-icon left>mdi-cash-check</v-icon>
             Bezahlt
           </v-chip>
 
-          <v-chip class="ma-2" color="orange" text-color="white" v-else>
+          <v-chip
+            class="ma-2"
+            color="orange"
+            text-color="white"
+            v-else
+          >
             <v-icon left>mdi-cash</v-icon>
             Zahlung ausstehend
           </v-chip>
@@ -262,6 +277,7 @@
 <script>
 import ApiBookingService from "@/services/api/ApiBookingService";
 import FormatService from "@/services/FormatService";
+import { isFreeBooking } from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "BookingStatus",
@@ -278,7 +294,8 @@ export default {
       return (
         this.bookingInfo &&
         this.bookingInfo.status.bookingStatus === "confirmed" &&
-        this.bookingInfo.status.paymentStatus === "paid"
+        (this.bookingInfo.status.paymentStatus === "paid" ||
+          isFreeBooking(this.bookingInfo))
       );
     },
     activeStatus() {
@@ -309,6 +326,7 @@ export default {
     };
   },
   methods: {
+    isFreeBooking,
     submitForm() {
       if (this.$refs.form.validate()) {
         this.fetchBookingStatus();

--- a/src/views/MultiCheckout/CheckoutStatus.vue
+++ b/src/views/MultiCheckout/CheckoutStatus.vue
@@ -227,6 +227,10 @@
 import ApiBookingService from "@/services/api/ApiBookingService";
 import ApiTenantService from "@/services/api/ApiTenantService";
 import ApiInstanceService from "@/services/api/ApiInstanceService";
+import {
+  isCheckoutStatusComplete,
+  isFreeBooking,
+} from "@/utils/bookingPaymentStatus";
 
 export default {
   name: "CheckoutSuccess",
@@ -335,7 +339,10 @@ export default {
         this.bookingStatuses = Array.isArray(res.data) ? res.data : [res.data];
 
         const pending = this.bookingStatuses
-          .filter((b) => (b.isCommitted && !b.isPayed) || b.isRejected)
+          .filter(
+            (b) =>
+              (b.isCommitted && !b.isPayed && !isFreeBooking(b)) || b.isRejected
+          )
           .map((b) => b.bookingId);
 
         if (pending.length === 0) {
@@ -371,7 +378,7 @@ export default {
         this.status = "cancelled";
         return;
       }
-      if (isCommitted && isPayed) {
+      if (isCheckoutStatusComplete(obj)) {
         this.status = "success";
       } else if (!isCommitted) {
         this.status = "await-approval";
@@ -388,6 +395,9 @@ export default {
       if (booking.isRejected && booking.isCommitted) {
         return "Storniert";
       }
+      if (booking.isCommitted && isFreeBooking(booking)) {
+        return "Abgeschlossen (kostenfrei)";
+      }
       if (booking.isCommitted && booking.isPayed) {
         return "Abgeschlossen";
       }
@@ -400,11 +410,16 @@ export default {
       return "Unbekannt";
     },
 
+    isCompletedStatusText(text) {
+      return text === "Abgeschlossen" || text === "Abgeschlossen (kostenfrei)";
+    },
+
     iconName(booking) {
       const txt = this.statusText(booking);
       if (txt === "Storniert") return "mdi-cancel";
       if (txt === "Abgelehnt") return "mdi-alert";
-      if (txt === "Abgeschlossen") return "mdi-check";
+      if (txt === "Abgeschlossen (kostenfrei)") return "mdi-gift";
+      if (this.isCompletedStatusText(txt)) return "mdi-check";
       if (txt === "In Prüfung") return "mdi-timer-sand-empty";
       if (txt === "Zahlung ausstehend") return "mdi-clock-outline";
       if (txt === "Zahlung fehlgeschlagen") return "mdi-alert";
@@ -419,7 +434,7 @@ export default {
         txt === "Storniert"
       )
         return "warning";
-      if (txt === "Abgeschlossen") return "success";
+      if (this.isCompletedStatusText(txt)) return "success";
       if (txt === "In Prüfung" || txt === "Zahlung ausstehend") return "info";
       return "";
     },
@@ -432,7 +447,7 @@ export default {
         txt === "Storniert"
       )
         return "orange lighten-4";
-      if (txt === "Abgeschlossen") return "green lighten-4";
+      if (this.isCompletedStatusText(txt)) return "green lighten-4";
       if (txt === "In Prüfung" || txt === "Zahlung ausstehend")
         return "blue lighten-4";
       return "grey lighten-3";
@@ -446,7 +461,7 @@ export default {
         txt === "Storniert"
       )
         return "orange darken-4";
-      if (txt === "Abgeschlossen") return "green darken-4";
+      if (this.isCompletedStatusText(txt)) return "green darken-4";
       if (txt === "In Prüfung" || txt === "Zahlung ausstehend")
         return "blue darken-4";
       return "grey darken-3";
@@ -463,7 +478,7 @@ export default {
 
     async doPoll() {
       const pending = this.bookingStatuses
-        .filter((b) => !((b.isCommitted && b.isPayed) || b.isRejected))
+        .filter((b) => !isCheckoutStatusComplete(b) && !b.isRejected)
         .map((b) => b.bookingId);
 
       if (pending.length === 0 || this.paymentProvider === "invoice") {

--- a/src/views/MultiCheckout/CheckoutStatus.vue
+++ b/src/views/MultiCheckout/CheckoutStatus.vue
@@ -341,7 +341,7 @@ export default {
         const pending = this.bookingStatuses
           .filter(
             (b) =>
-              (b.isCommitted && !b.isPayed && !isFreeBooking(b)) || b.isRejected
+              b.isCommitted && !b.isRejected && !isCheckoutStatusComplete(b)
           )
           .map((b) => b.bookingId);
 


### PR DESCRIPTION
## Summary
- Introduces `src/utils/bookingPaymentStatus.js` as a shared helper for deriving the visible payment status from `priceEur` and `isPayed`
- Updates admin and public UI (booking table, details, kanban, export, checkout status, public booking status, JS widget) to show **Kostenfrei** for zero-price bookings instead of **Bezahlt**
- Keeps the `isPayed` switch editable in `BookingEditStatus` for manual overrides

## Test plan
- [x] Open a free booking (`priceEur = 0`) in the booking table and verify the payment column shows **Kostenfrei**
- [x] Open booking details and verify the payment chip shows **Kostenfrei** (no paid date unless actually paid with price > 0)
- [x] Complete a free checkout and verify checkout status shows **Abgeschlossen (kostenfrei)**
- [x] Export bookings and verify the payment column shows **Kostenfrei** for zero-price rows
- [x] Verify paid bookings (`priceEur > 0`, `isPayed = true`) still show **Bezahlt**
- [x] Verify unpaid paid bookings still show **Offen** / **Zahlung ausstehend**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified payment-status experience across booking views, including a dedicated “Kostenfrei” flow for complimentary bookings.
  * Improved checkout status handling, labeling, and UI styling for free-completed cases.

* **Bug Fixes**
  * Fixed payment chip visibility and the displayed payment date logic so “paid/pending” indicators align with the actual booking payment state.
  * Updated multi-checkout completion and polling logic so success/pending transitions correctly reflect free vs paid bookings, including Excel export consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->