### PR TITLE
feat: extend lead-time config to time-period and block-period bookables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,17 @@ Notable changes for the Smart City Booking Admin UI.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Releases are tagged `v4.x.x` from branch `version/4.x`.
 
+## [Unreleased]
+
+### Added
+
+- Lead-time configuration (preparation lead time and service hours) for fixed time-window and block-period bookables in the bookable editor
+
+### Changed
+
+- Lead-time editor placement: time-window and block-period configuration appears before lead-time settings for those booking types
+- Booking buffer settings remain available only for free time-selection (`schedule`) bookables
+
 ## [4.1.1] — 2026-07-01
 
 ### Fixed

--- a/src/components/Bookable/Edit/BookableEditBookingType.vue
+++ b/src/components/Bookable/Edit/BookableEditBookingType.vue
@@ -60,6 +60,11 @@ export default {
         this.model.longRangeOptions.type === "month"
       );
     },
+    bookingTypeSupportsLeadTime() {
+      return ["schedule", "timePeriod", "blockPeriod"].includes(
+        this.bookingType
+      );
+    },
     bookingType: {
       get() {
         if (this.model.isScheduleRelated) return "schedule";
@@ -77,29 +82,29 @@ export default {
         this.model.isLongRange = false;
 
         switch (value) {
-        case "schedule":
-          this.model.isScheduleRelated = true;
-          break;
-        case "timePeriod":
-          this.model.isTimePeriodRelated = true;
-          break;
-        case "blockPeriod":
-          this.model.isBlockPeriodRelated = true;
-          if (!Array.isArray(this.model.blockPeriods)) {
-            this.model.blockPeriods = [];
-          }
-          if (this.model.groupBooking?.enabled) {
-            this.model.groupBooking.enabled = false;
-          }
-          break;
-        case "week":
-          this.model.longRangeOptions = { type: "week" };
-          this.model.isLongRange = true;
-          break;
-        case "month":
-          this.model.longRangeOptions = { type: "month" };
-          this.model.isLongRange = true;
-          break;
+          case "schedule":
+            this.model.isScheduleRelated = true;
+            break;
+          case "timePeriod":
+            this.model.isTimePeriodRelated = true;
+            break;
+          case "blockPeriod":
+            this.model.isBlockPeriodRelated = true;
+            if (!Array.isArray(this.model.blockPeriods)) {
+              this.model.blockPeriods = [];
+            }
+            if (this.model.groupBooking?.enabled) {
+              this.model.groupBooking.enabled = false;
+            }
+            break;
+          case "week":
+            this.model.longRangeOptions = { type: "week" };
+            this.model.isLongRange = true;
+            break;
+          case "month":
+            this.model.longRangeOptions = { type: "month" };
+            this.model.isLongRange = true;
+            break;
         }
       },
     },
@@ -110,7 +115,7 @@ export default {
       if (!formValid) {
         return false;
       }
-      if (this.bookingType === "schedule" && this.$refs.leadTime) {
+      if (this.bookingTypeSupportsLeadTime && this.$refs.leadTime) {
         const leadTimeValid = await this.$refs.leadTime.validate();
         if (!leadTimeValid) {
           return false;
@@ -167,10 +172,7 @@ export default {
     isBlockPeriodComplete(blockPeriod) {
       const { startWeekday, endWeekday, startTime, endTime } = blockPeriod;
       return (
-        startWeekday != null &&
-        endWeekday != null &&
-        !!startTime &&
-        !!endTime
+        startWeekday != null && endWeekday != null && !!startTime && !!endTime
       );
     },
     getBlockPeriodDurationMinutes(blockPeriod) {
@@ -333,8 +335,7 @@ export default {
                 Feste Zeitfenster
               </div>
               <div class="text-caption text--secondary mt-1">
-                Vordefinierte, buchbare Zeitfenster (z.B. Montags 09:00 -
-                12:00)
+                Vordefinierte, buchbare Zeitfenster (z.B. Montags 09:00 - 12:00)
               </div>
             </div>
           </template>
@@ -443,10 +444,16 @@ export default {
         v-if="bookingType === 'schedule'"
         ref="leadTime"
         :bookable="model"
+        :show-buffer="true"
         @update:bookable="model = $event"
       />
 
-      <v-card class="mt-4 section-card" v-if="bookingType === 'timePeriod'">
+      <v-card
+        class="mt-4 section-card"
+        v-if="bookingType === 'timePeriod'"
+        elevation="2"
+        outlined
+      >
         <v-card-title
           class="section-header pa-4 d-flex justify-space-between align-center"
         >
@@ -490,9 +497,7 @@ export default {
                         }}
                       </span>
                     </v-list-item-title>
-                    <v-list-item-subtitle
-                      class="d-flex align-center flex-wrap"
-                    >
+                    <v-list-item-subtitle class="d-flex align-center flex-wrap">
                       <v-icon small class="mr-1">mdi-clock-outline</v-icon>
                       <span v-if="timePeriod.startTime && timePeriod.endTime">
                         {{ timePeriod.startTime }} - {{ timePeriod.endTime }}
@@ -504,11 +509,7 @@ export default {
 
                   <v-list-item-action>
                     <div class="d-flex align-center">
-                      <v-btn
-                        icon
-                        small
-                        @click.stop="removeTimePeriod(index)"
-                      >
+                      <v-btn icon small @click.stop="removeTimePeriod(index)">
                         <v-icon small>mdi-delete-outline</v-icon>
                       </v-btn>
                       <v-btn icon small>
@@ -642,7 +643,9 @@ export default {
                             v-if="timeEndMenu[index]"
                             v-model="timePeriod.endTime"
                             full-width
-                            @click:minute="setEndTime(index, timePeriod.endTime)"
+                            @click:minute="
+                              setEndTime(index, timePeriod.endTime)
+                            "
                             format="24hr"
                           ></v-time-picker>
                         </v-menu>
@@ -668,8 +671,7 @@ export default {
               Noch keine Zeitfenster definiert
             </div>
             <div class="text-body-2 grey--text text--darken-1 mb-4">
-              Fügen Sie Zeitfenster hinzu, um feste Buchungszeiten zu
-              definieren
+              Fügen Sie Zeitfenster hinzu, um feste Buchungszeiten zu definieren
             </div>
             <v-btn small text color="primary" @click="addNewTimePeriod">
               <v-icon left small>mdi-plus</v-icon>
@@ -679,7 +681,20 @@ export default {
         </v-card-text>
       </v-card>
 
-      <v-card class="mt-4 section-card" v-if="bookingType === 'blockPeriod'">
+      <BookableEditLeadTime
+        v-if="bookingType === 'timePeriod'"
+        ref="leadTime"
+        :bookable="model"
+        :show-buffer="false"
+        @update:bookable="model = $event"
+      />
+
+      <v-card
+        class="mt-4 section-card"
+        v-if="bookingType === 'blockPeriod'"
+        elevation="2"
+        outlined
+      >
         <v-card-title
           class="section-header pa-4 d-flex justify-space-between align-center"
         >
@@ -735,9 +750,7 @@ export default {
                         {{ blockPeriod.label || "Ohne Bezeichnung" }}
                       </span>
                     </v-list-item-title>
-                    <v-list-item-subtitle
-                      class="d-flex align-center flex-wrap"
-                    >
+                    <v-list-item-subtitle class="d-flex align-center flex-wrap">
                       <v-icon small class="mr-1">mdi-clock-outline</v-icon>
                       <span
                         v-if="
@@ -757,11 +770,7 @@ export default {
 
                   <v-list-item-action>
                     <div class="d-flex align-center">
-                      <v-btn
-                        icon
-                        small
-                        @click.stop="removeBlockPeriod(index)"
-                      >
+                      <v-btn icon small @click.stop="removeBlockPeriod(index)">
                         <v-icon small>mdi-delete-outline</v-icon>
                       </v-btn>
                       <v-btn icon small>
@@ -794,7 +803,8 @@ export default {
                           v-model="blockPeriod.label"
                           hide-details="auto"
                           :rules="[
-                            (v) => !!v?.trim() || 'Bezeichnung ist erforderlich',
+                            (v) =>
+                              !!v?.trim() || 'Bezeichnung ist erforderlich',
                           ]"
                         />
                       </v-col>
@@ -954,8 +964,8 @@ export default {
               Noch keine Zeiträume definiert
             </div>
             <div class="text-body-2 grey--text text--darken-1 mb-4">
-              Fügen Sie Zeiträume hinzu, um wiederkehrende Buchungsfenster
-              zu definieren
+              Fügen Sie Zeiträume hinzu, um wiederkehrende Buchungsfenster zu
+              definieren
             </div>
             <v-btn small text color="primary" @click="addNewBlockPeriod">
               <v-icon left small>mdi-plus</v-icon>
@@ -964,6 +974,14 @@ export default {
           </div>
         </v-card-text>
       </v-card>
+
+      <BookableEditLeadTime
+        v-if="bookingType === 'blockPeriod'"
+        ref="leadTime"
+        :bookable="model"
+        :show-buffer="false"
+        @update:bookable="model = $event"
+      />
     </BaseSection>
   </v-form>
 </template>

--- a/src/components/Bookable/Edit/BookableEditLeadTime.vue
+++ b/src/components/Bookable/Edit/BookableEditLeadTime.vue
@@ -32,6 +32,7 @@ export default {
   name: "BookableEditLeadTime",
   props: {
     bookable: { type: Object, required: true },
+    showBuffer: { type: Boolean, default: true },
   },
   data() {
     return {
@@ -242,6 +243,7 @@ export default {
           ));
 
       const bufferValid =
+        !this.showBuffer ||
         !this.model.isBufferRelated ||
         (this.isBufferMinutesValid(this.model.bufferTimeBeforeMinutes) &&
           this.isBufferMinutesValid(this.model.bufferTimeAfterMinutes) &&
@@ -561,7 +563,7 @@ export default {
       </v-card-text>
     </v-card>
 
-    <v-card class="mt-4 section-card" elevation="2" outlined>
+    <v-card v-if="showBuffer" class="mt-4 section-card" elevation="2" outlined>
       <v-card-title class="section-header pa-4">
         <v-icon class="mr-2">mdi-calendar-clock</v-icon>
         <span class="text-h6 font-weight-bold">Puffer zwischen Buchungen</span>

--- a/src/utils/bookingLeadTime.js
+++ b/src/utils/bookingLeadTime.js
@@ -1,5 +1,13 @@
+export function supportsLeadTime(bookable) {
+  return (
+    bookable?.isScheduleRelated === true ||
+    bookable?.isTimePeriodRelated === true ||
+    bookable?.isBlockPeriodRelated === true
+  );
+}
+
 export function hasLeadTimeConfig(bookable) {
-  if (!bookable?.isScheduleRelated) {
+  if (!supportsLeadTime(bookable)) {
     return false;
   }
   const minutes = Number(bookable.preparationLeadTimeMinutes);
@@ -45,6 +53,8 @@ export function normalizeLeadTimeFields(bookable) {
   if (!bookable) {
     return bookable;
   }
+  const leadTimeSupported = supportsLeadTime(bookable);
+  const bufferSupported = bookable?.isScheduleRelated === true;
 
   if (!Array.isArray(bookable.serviceHours)) {
     bookable.serviceHours = [];
@@ -53,20 +63,28 @@ export function normalizeLeadTimeFields(bookable) {
     bookable.preparationLeadTimeMinutes = 0;
   }
 
-  if (!bookable.isScheduleRelated) {
+  if (!leadTimeSupported) {
     bookable.isLeadTimeRelated = false;
+  }
+
+  if (!bufferSupported) {
     bookable.isBufferRelated = false;
     bookable.bufferTimeBeforeMinutes = null;
     bookable.bufferTimeAfterMinutes = null;
+  }
+
+  if (!leadTimeSupported) {
     return bookable;
   }
 
-  bookable.bufferTimeBeforeMinutes = normalizeBufferMinutes(
-    bookable.bufferTimeBeforeMinutes
-  );
-  bookable.bufferTimeAfterMinutes = normalizeBufferMinutes(
-    bookable.bufferTimeAfterMinutes
-  );
+  if (bufferSupported) {
+    bookable.bufferTimeBeforeMinutes = normalizeBufferMinutes(
+      bookable.bufferTimeBeforeMinutes
+    );
+    bookable.bufferTimeAfterMinutes = normalizeBufferMinutes(
+      bookable.bufferTimeAfterMinutes
+    );
+  }
 
   const hasExistingLeadTimeConfig = hasLeadTimeConfig(bookable);
   const hasServiceHours = bookable.serviceHours.length > 0;
@@ -77,10 +95,12 @@ export function normalizeLeadTimeFields(bookable) {
     bookable.isLeadTimeRelated = false;
   }
 
-  if (hasBufferConfig(bookable)) {
-    bookable.isBufferRelated = true;
-  } else {
-    bookable.isBufferRelated = false;
+  if (bufferSupported) {
+    if (hasBufferConfig(bookable)) {
+      bookable.isBufferRelated = true;
+    } else {
+      bookable.isBufferRelated = false;
+    }
   }
 
   return bookable;


### PR DESCRIPTION
## Summary
- Enable preparation lead time and service hours in the bookable editor for fixed time-window and block-period booking types
- Keep booking buffer settings schedule-only via `showBuffer` and updated lead-time normalization
- Show type-specific configuration (time windows / block periods) before lead-time settings for those booking types

## Test plan
- [x] Open a bookable with booking type "Feste Zeitfenster" and verify time-window configuration appears above lead-time settings
- [x] Configure preparation lead time and service hours, save, reload, and confirm values persist
- [x] Open a bookable with booking type "Zeiträume" and verify block-period configuration appears above lead-time settings
- [x] Confirm buffer settings are not shown for time-window and block-period bookables
- [x] Confirm schedule bookables still show lead time and buffer settings after booking duration
- [x] Confirm long-range and independent bookables do not show lead-time configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lead-time settings are now available for fixed time-window and block-period bookings, not just free time-selection bookings.
  * Buffer settings are hidden for booking types that don’t support them.

* **Bug Fixes**
  * Validation now correctly applies lead-time rules across supported booking types.
  * Lead-time and buffer fields are normalized more consistently when switching booking types.

* **Documentation**
  * Updated the changelog with the latest booking configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->