### PR TITLE
feat(DEV-626): Serienbuchungen im Kanban erkennbar machen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Series bookings in the Kanban board are now visually marked with a chip and accent border; the series can be opened directly from the card (DEV-626)
+- Booking overview filter for booking type: all, single bookings only, or series bookings only — accessible via filter button in the search field (DEV-626)
 - Admin UI for supervisor booking notifications (DEV-779): manage `bookingNotificationRecipients` per tenant member (user, role, email; max. 10) in the member detail dialog
 - Tenant feature flag `notifySupervisorsOnBooking` toggle in booking settings
 - Overridable mail snippet `supervisor-booking-notification` in tenant mail configuration

--- a/src/components/Booking/BookingKanban.vue
+++ b/src/components/Booking/BookingKanban.vue
@@ -42,6 +42,7 @@
           @drag-move="onMove"
           @open-booking="onOpenBooking"
           @open-edit-booking="onOpenEditBooking"
+          @open-group-booking="onOpenGroupBooking"
           @commit-booking="commitBooking"
           @reject-booking="rejectBooking"
           @archive-task="archiveTask"
@@ -64,6 +65,7 @@
         @drag-move="onMove"
         @open-booking="onOpenBooking"
         @open-edit-booking="onOpenEditBooking"
+        @open-group-booking="onOpenGroupBooking"
         @commit-booking="commitBooking"
         @pay-booking="payBooking"
         @reject-booking="rejectBooking"
@@ -212,6 +214,9 @@ export default {
     },
     onOpenEditBooking(bookingId) {
       this.$emit("open-edit-booking", bookingId);
+    },
+    onOpenGroupBooking(groupBookingId) {
+      this.$emit("open-group-booking", groupBookingId);
     },
     commitBooking(bookingId) {
       this.$emit("commit-booking", bookingId);

--- a/src/components/Booking/BookingKanbanCard.vue
+++ b/src/components/Booking/BookingKanbanCard.vue
@@ -1,7 +1,10 @@
 <template>
   <v-card
     class="kanban-card mb-2"
-    :class="{ 'kanban-card--dragging': isDragging }"
+    :class="{
+      'kanban-card--dragging': isDragging,
+      'kanban-card--series': !!element.bookingItem?.groupBooking,
+    }"
     @click="onOpenBooking(element.bookingItem.id)"
     hover
     outlined
@@ -35,6 +38,16 @@
               <v-icon small>mdi-pencil</v-icon>
             </v-list-item-icon>
             <v-list-item-title>Bearbeiten</v-list-item-title>
+          </v-list-item>
+
+          <v-list-item
+            v-if="element.bookingItem?.groupBooking"
+            @click.stop="onOpenGroupBooking(element.bookingItem.groupBooking)"
+          >
+            <v-list-item-icon>
+              <v-icon small>mdi-calendar-multiple</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>Serienbuchung öffnen</v-list-item-title>
           </v-list-item>
 
           <v-divider />
@@ -89,6 +102,17 @@
         <v-icon x-small class="mr-1">mdi-package-variant</v-icon>
         {{ bookableTitle }}
       </div>
+      <v-chip
+        v-if="element.bookingItem?.groupBooking"
+        x-small
+        color="primary"
+        text-color="white"
+        class="mt-1 series-chip"
+        @click.stop="onOpenGroupBooking(element.bookingItem.groupBooking)"
+      >
+        <v-icon x-small left>mdi-calendar-multiple</v-icon>
+        Serie {{ truncate(element.bookingItem.groupBooking, 10) }}
+      </v-chip>
     </div>
 
     <div class="d-flex align-center justify-space-between px-2 pb-2">
@@ -193,6 +217,13 @@ export default {
     onOpenEditBooking(bookingId) {
       this.$emit("open-edit-booking", bookingId);
     },
+    onOpenGroupBooking(groupBookingId) {
+      this.$emit("open-group-booking", groupBookingId);
+    },
+    truncate(text, max = 25) {
+      if (!text) return "";
+      return text.length > max ? text.slice(0, max - 1) + "…" : text;
+    },
     commitBooking(bookingId) {
       this.$emit("commit-booking", bookingId);
     },
@@ -218,12 +249,21 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.series-chip {
+  cursor: pointer;
+  max-width: 100%;
+}
+
 .kanban-card {
   border-radius: 8px !important;
   transition: all 0.2s cubic-bezier(0.25, 0.8, 0.5, 1);
   cursor: grab;
   min-width: 200px;
   max-width: 220px;
+
+  &--series {
+    border-left: 3px solid var(--v-primary-base) !important;
+  }
 
   &:hover {
     transform: translateY(-2px);

--- a/src/components/Booking/KanbanColumn.vue
+++ b/src/components/Booking/KanbanColumn.vue
@@ -47,6 +47,7 @@
             :backlog="statusId === 'backlog'"
             @open-booking="onOpenBooking"
             @open-edit-booking="onOpenEditBooking"
+            @open-group-booking="onOpenGroupBooking"
             @commit-booking="onCommitBooking"
             @pay-booking="onPayBooking"
             @reject-booking="onRejectBooking"
@@ -119,6 +120,9 @@ export default {
     },
     onOpenEditBooking(bookingId) {
       this.$emit("open-edit-booking", bookingId);
+    },
+    onOpenGroupBooking(groupBookingId) {
+      this.$emit("open-group-booking", groupBookingId);
     },
     onCommitBooking(bookingId) {
       this.$emit("commit-booking", bookingId);

--- a/src/views/Bookings.vue
+++ b/src/views/Bookings.vue
@@ -52,7 +52,108 @@
         solo
         clearable
         class="search-field"
-      ></v-text-field>
+      >
+        <template v-slot:prepend-inner>
+          <v-menu
+            bottom
+            left
+            offset-y
+            nudge-bottom="8"
+            max-width="320"
+            content-class="booking-type-filter-menu"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <v-badge
+                :value="hasActiveBookingTypeFilter"
+                color="primary"
+                dot
+                overlap
+              >
+                <v-btn
+                  icon
+                  v-bind="attrs"
+                  v-on="on"
+                  class="booking-type-filter-trigger"
+                  :class="{
+                    'booking-type-filter-trigger--active':
+                      hasActiveBookingTypeFilter,
+                  }"
+                  @click.stop
+                >
+                  <v-icon>mdi-filter-variant</v-icon>
+                </v-btn>
+              </v-badge>
+            </template>
+
+            <v-card class="booking-type-filter-card" elevation="8" rounded="lg">
+              <div class="booking-type-filter-card__header">
+                <div class="d-flex align-center">
+                  <div class="booking-type-filter-card__header-icon mr-3">
+                    <v-icon color="primary" small>mdi-tune-variant</v-icon>
+                  </div>
+                  <div>
+                    <div class="text-subtitle-2 font-weight-bold line-height-tight">
+                      Buchungstyp
+                    </div>
+                    <div class="text-caption grey--text">
+                      Ansicht einschränken
+                    </div>
+                  </div>
+                </div>
+                <v-btn
+                  v-if="hasActiveBookingTypeFilter"
+                  text
+                  x-small
+                  color="primary"
+                  class="px-2"
+                  @click="bookingTypeFilter = 'all'"
+                >
+                  Zurücksetzen
+                </v-btn>
+              </div>
+
+              <v-divider />
+
+              <div class="booking-type-filter-card__options">
+                <button
+                  v-for="option in bookingTypeFilterOptions"
+                  :key="option.value"
+                  type="button"
+                  class="booking-type-filter-option"
+                  :class="{
+                    'booking-type-filter-option--active':
+                      bookingTypeFilter === option.value,
+                  }"
+                  @click="bookingTypeFilter = option.value"
+                >
+                  <div
+                    class="booking-type-filter-option__icon"
+                    :class="`booking-type-filter-option__icon--${option.value}`"
+                  >
+                    <v-icon small>{{ option.icon }}</v-icon>
+                  </div>
+                  <div class="booking-type-filter-option__content">
+                    <span class="booking-type-filter-option__title">{{
+                      option.text
+                    }}</span>
+                    <span class="booking-type-filter-option__desc">{{
+                      option.description
+                    }}</span>
+                  </div>
+                  <v-icon
+                    v-if="bookingTypeFilter === option.value"
+                    small
+                    color="primary"
+                    class="booking-type-filter-option__check"
+                  >
+                    mdi-check-circle
+                  </v-icon>
+                </button>
+              </div>
+            </v-card>
+          </v-menu>
+        </template>
+      </v-text-field>
     </div>
 
     <div class="page-content">
@@ -96,6 +197,7 @@
           :show-backlog="showBacklog"
           @open-booking="onOpenBooking"
           @open-edit-booking="onOpenEditBooking"
+          @open-group-booking="onOpenGroupBooking"
           @pay-booking="onPayBooking"
           @commit-booking="commitBooking"
           @update:booking="fetchBooking"
@@ -240,6 +342,27 @@ export default {
       fuse: null,
       value: "",
       searchTerm: "",
+      bookingTypeFilter: "all",
+      bookingTypeFilterOptions: [
+        {
+          value: "all",
+          text: "Alle Buchungen",
+          description: "Einzel- und Serienbuchungen",
+          icon: "mdi-view-grid-outline",
+        },
+        {
+          value: "single",
+          text: "Einzelbuchungen",
+          description: "Ohne Serienzuordnung",
+          icon: "mdi-calendar-check-outline",
+        },
+        {
+          value: "series",
+          text: "Serienbuchungen",
+          description: "Teil einer Buchungsserie",
+          icon: "mdi-calendar-multiple",
+        },
+      ],
       api: {
         users: [],
         bookings: [],
@@ -289,6 +412,9 @@ export default {
     BookingPermissionService() {
       return BookingPermissionService;
     },
+    hasActiveBookingTypeFilter() {
+      return this.bookingTypeFilter !== "all";
+    },
     mappedBookings() {
       return this.api.bookings.map((booking) => {
         return {
@@ -300,43 +426,46 @@ export default {
       });
     },
     filteredBookings() {
-      if (!this.searchTerm) {
-        return this.mappedBookings || [];
-      }
-      const terms = this.searchTerm.trim().split(/\s+/);
-      const searchQuery = {
-        $and: terms.map((term) => ({
-          $or: [
-            { id: `'${term}` },
-            { mail: `'${term}` },
-            { comment: `'${term}` },
-            { name: `'${term}` },
-            { street: `'${term}` },
-            { zipCode: `'${term}` },
-            { location: `'${term}` },
-            { company: `'${term}` },
-            { phone: `'${term}` },
-            { "bookableItems.bookableId": `'${term}` },
-            { "bookableItems._bookableUsed.id": `'${term}` },
-            { "bookableItems._bookableUsed.title": `'${term}` },
-            { "bookableItems._bookableUsed.description": `'${term}` },
-            { "bookableItems._bookableUsed.type": `'${term}` },
-            { "bookableItems._bookableUsed.eventId": `'${term}` },
-            { "bookableItems._bookableUsed.priceEur": `'${term}` },
-            { "bookableItems._bookableUsed.attachments.id": `'${term}` },
-            { "bookableItems._bookableUsed.attachments.type": `'${term}` },
-            { "bookableItems._bookableUsed.attachments.title": `'${term}` },
-            { "bookableItems._bookableUsed.attachments.url": `'${term}` },
-            { "_populated.bookable.flags": `'${term}` },
-            { "_populated.bookable.tags": `'${term}` },
-            { "_populated.bookable.bookingNotes": `'${term}` },
-            { groupBooking: `'${term}` },
-          ],
-        })),
-      };
+      let bookings = this.mappedBookings || [];
 
-      const results = this.fuse.search(searchQuery);
-      return results.map((result) => result.item);
+      if (this.searchTerm) {
+        const terms = this.searchTerm.trim().split(/\s+/);
+        const searchQuery = {
+          $and: terms.map((term) => ({
+            $or: [
+              { id: `'${term}` },
+              { mail: `'${term}` },
+              { comment: `'${term}` },
+              { name: `'${term}` },
+              { street: `'${term}` },
+              { zipCode: `'${term}` },
+              { location: `'${term}` },
+              { company: `'${term}` },
+              { phone: `'${term}` },
+              { "bookableItems.bookableId": `'${term}` },
+              { "bookableItems._bookableUsed.id": `'${term}` },
+              { "bookableItems._bookableUsed.title": `'${term}` },
+              { "bookableItems._bookableUsed.description": `'${term}` },
+              { "bookableItems._bookableUsed.type": `'${term}` },
+              { "bookableItems._bookableUsed.eventId": `'${term}` },
+              { "bookableItems._bookableUsed.priceEur": `'${term}` },
+              { "bookableItems._bookableUsed.attachments.id": `'${term}` },
+              { "bookableItems._bookableUsed.attachments.type": `'${term}` },
+              { "bookableItems._bookableUsed.attachments.title": `'${term}` },
+              { "bookableItems._bookableUsed.attachments.url": `'${term}` },
+              { "_populated.bookable.flags": `'${term}` },
+              { "_populated.bookable.tags": `'${term}` },
+              { "_populated.bookable.bookingNotes": `'${term}` },
+              { groupBooking: `'${term}` },
+            ],
+          })),
+        };
+
+        const results = this.fuse.search(searchQuery);
+        bookings = results.map((result) => result.item);
+      }
+
+      return this.applyBookingTypeFilter(bookings);
     },
   },
   watch: {
@@ -358,6 +487,15 @@ export default {
       startLoading: "loading/start",
       stopLoading: "loading/stop",
     }),
+    applyBookingTypeFilter(bookings) {
+      if (this.bookingTypeFilter === "single") {
+        return bookings.filter((booking) => !booking.groupBooking);
+      }
+      if (this.bookingTypeFilter === "series") {
+        return bookings.filter((booking) => !!booking.groupBooking);
+      }
+      return bookings;
+    },
     async onDownloadGroupBookingIcal(bookingIds) {
       const operationId = ProcessingService.showSnackbar(
         "Termine werden heruntergeladen..."
@@ -940,6 +1078,162 @@ export default {
 .search-field {
   border-radius: 15px;
 }
+
+.booking-type-filter-trigger--active {
+  background: rgba(var(--v-primary-base), 0.12) !important;
+
+  .v-icon {
+    color: var(--v-primary-base) !important;
+  }
+}
+
+.booking-type-filter-card {
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.booking-type-filter-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 12px;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-primary-base), 0.06) 0%,
+    rgba(var(--v-primary-base), 0.02) 100%
+  );
+}
+
+.booking-type-filter-card__header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(var(--v-primary-base), 0.12);
+}
+
+.line-height-tight {
+  line-height: 1.25;
+}
+
+.booking-type-filter-card__options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+}
+
+.booking-type-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1.5px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.04);
+    transform: translateX(2px);
+  }
+
+  &--active {
+    background: rgba(var(--v-primary-base), 0.08);
+    border-color: rgba(var(--v-primary-base), 0.35);
+    box-shadow: 0 2px 8px rgba(var(--v-primary-base), 0.12);
+
+    .booking-type-filter-option__title {
+      color: var(--v-primary-base);
+      font-weight: 600;
+    }
+  }
+}
+
+.booking-type-filter-option__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  transition: transform 0.2s ease;
+
+  .booking-type-filter-option--active & {
+    transform: scale(1.05);
+  }
+
+  &--all {
+    background: transparent;
+    color: #607d8b;
+  }
+
+  &--single {
+    background: transparent;
+    color: #2196f3;
+  }
+
+  &--series {
+    background: rgba(var(--v-primary-base), 0.16);
+    color: var(--v-primary-base);
+  }
+}
+
+.booking-type-filter-option__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.booking-type-filter-option__title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.booking-type-filter-option__desc {
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: rgba(0, 0, 0, 0.54);
+  margin-top: 2px;
+}
+
+.booking-type-filter-option__check {
+  flex-shrink: 0;
+}
+
+.theme--dark {
+  .booking-type-filter-card {
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .booking-type-filter-option {
+    &:hover {
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    &--active {
+      background: rgba(var(--v-primary-base), 0.15);
+    }
+  }
+
+  .booking-type-filter-option__title {
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .booking-type-filter-option__desc {
+    color: rgba(255, 255, 255, 0.55);
+  }
+}
+
 ::v-deep .active-button {
   color: black !important;
   background-color: var(--v-secondary-base) !important;
@@ -968,5 +1262,17 @@ body {
 
 .page-footer {
   flex: 0 0 auto;
+}
+</style>
+
+<style lang="scss">
+.booking-type-filter-menu {
+  border-radius: 14px !important;
+  overflow: hidden;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.14) !important;
+
+  .v-card {
+    border-radius: 14px !important;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Serienbuchungen sind im Kanban-Board auf den ersten Blick erkennbar (Chip, Akzent-Rand, Kontextmenü zum Öffnen der Serie)
- Neuer Buchungstyp-Filter über den Filter-Button im Suchfeld (Alle / Einzelbuchungen / Serienbuchungen) für Liste, Kalender und Kanban
- Changelog unter `[Unreleased]` ergänzt

## Test plan
- [ ] Kanban mit Serienbuchungen öffnen: Karten zeigen Serie-Chip und linken Akzent-Rand
- [ ] Klick auf Serie-Chip oder „Serienbuchung öffnen“ im Kontextmenü öffnet den Serienbuchungs-Dialog
- [ ] Filter-Button im Suchfeld: Dropdown mit drei Optionen, Badge-Punkt bei aktivem Filter
- [ ] Filter „Einzelbuchungen“ blendet Serienbuchungen in allen drei Ansichten aus
- [ ] Filter „Serienbuchungen“ zeigt nur Buchungen mit Serienzuordnung
- [ ] „Zurücksetzen“ im Filter-Dropdown setzt auf „Alle“ zurück
- [ ] Textsuche und Buchungstyp-Filter funktionieren kombiniert
- [ ] Drag & Drop im Kanban weiterhin ohne Regression