### PR TITLE
fix(DEV-784): use substring search for member and user lists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Tenant feature flag `notifySupervisorsOnBooking` toggle in booking settings
 - Overridable mail snippet `supervisor-booking-notification` in tenant mail configuration
 
+### Fixed
+
+- Member and instance user search now uses case-insensitive substring matching on name and email instead of fuzzy matching, preventing unrelated results (DEV-784)
+
 
 ## [4.1.3] — 2026-07-03
 

--- a/src/views/Management/InstanceUsers.vue
+++ b/src/views/Management/InstanceUsers.vue
@@ -314,7 +314,6 @@ import ApiRolesService from "@/services/api/ApiRolesService";
 import UserEdit from "@/components/User/UserEdit";
 import UserDeleteConformationDialog from "@/components/User/userDeleteConformationDialog";
 import UserPermissionService from "@/services/permissions/UserPermissionService";
-import Fuse from "fuse.js";
 import ApiMembershipService from "@/services/api/ApiMembershipService";
 import ApiTenantService from "@/services/api/ApiTenantService";
 
@@ -364,12 +363,15 @@ export default {
       let filtered = this.api.users;
 
       if (this.search) {
-        const fuse = new Fuse(filtered, {
-          keys: ["id", "firstName", "lastName"],
-          threshold: 0.4,
-          ignoreLocation: true,
-        });
-        filtered = fuse.search(this.search).map((result) => result.item);
+        const searchLower = this.search.toLowerCase().trim();
+        if (searchLower) {
+          filtered = filtered.filter((user) => {
+            const fullName = `${user.firstName || ""} ${user.lastName || ""}`.trim();
+            return [user.id, user.firstName, user.lastName, fullName].some(
+              (field) => field?.toLowerCase().includes(searchLower)
+            );
+          });
+        }
       }
 
       if (this.verifiedFilter) {

--- a/src/views/Management/TenantUsers.vue
+++ b/src/views/Management/TenantUsers.vue
@@ -411,7 +411,6 @@ import ApiRolesService from "@/services/api/ApiRolesService";
 import ApiTenantService from "@/services/api/ApiTenantService";
 import ApiInvitationService from "@/services/api/ApiInvitationService";
 import ToastService from "@/services/ToastService";
-import Fuse from "fuse.js";
 import TenantInviteUserDialog from "@/components/Tenant/TenantInviteUserDialog.vue";
 import ApiChallengeService from "@/services/api/ApiChallengeService";
 import TenantUserDetailDialog from "@/components/Tenant/TenantUserDetailsDialog.vue";
@@ -476,12 +475,14 @@ export default {
       let filtered = this.members;
 
       if (this.search) {
-        const fuse = new Fuse(filtered, {
-          keys: ["userId", "firstName", "lastName", "fullName"],
-          threshold: 0.4,
-          ignoreLocation: true,
-        });
-        filtered = fuse.search(this.search).map((result) => result.item);
+        const searchLower = this.search.toLowerCase().trim();
+        if (searchLower) {
+          filtered = filtered.filter((user) =>
+            [user.userId, user.firstName, user.lastName, user.fullName].some(
+              (field) => field?.toLowerCase().includes(searchLower)
+            )
+          );
+        }
       }
 
       if (this.statusFilter.length > 0) {


### PR DESCRIPTION
## Summary

- Replace Fuse.js fuzzy search with case-insensitive substring matching in the tenant member list (`TenantUsers.vue`) and instance user list (`InstanceUsers.vue`)
- Search now only returns results where the query appears as a substring in name or email fields
- Update `CHANGELOG.md` under `[Unreleased] → Fixed`
