### PR TITLE
feat(DEV-781): per-user/role booking discounts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Admin UI for supervisor booking notifications (DEV-779): manage `bookingNotificationRecipients` per tenant member (user, role, email; max. 10) in the member detail dialog
 - Bookable permissions: per-user and per-role booking discounts with percentage field (0–100) replace the previous free-booking lists (DEV-781)
 - Bundle checkout: role/user booking discounts shown via `bookingDiscountPercent`; opt-out uses `bookWithoutDiscount` instead of `bookWithPrice` (DEV-781)
+
+### Fixed
+
+- Bundle checkout: payment step is shown when additional bookables require payment, even if the lead bookable is free via role discount (DEV-781)
 - Tenant feature flag `notifySupervisorsOnBooking` toggle in booking settings
 - Overridable mail snippet `supervisor-booking-notification` in tenant mail configuration
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Series bookings in the Kanban board are now visually marked with a chip and accent border; the series can be opened directly from the card (DEV-626)
 - Booking overview filter for booking type: all, single bookings only, or series bookings only — accessible via filter button in the search field (DEV-626)
 - Admin UI for supervisor booking notifications (DEV-779): manage `bookingNotificationRecipients` per tenant member (user, role, email; max. 10) in the member detail dialog
+- Bookable permissions: per-user and per-role booking discounts with percentage field (0–100) replace the previous free-booking lists (DEV-781)
+- Bundle checkout: role/user booking discounts shown via `bookingDiscountPercent`; opt-out uses `bookWithoutDiscount` instead of `bookWithPrice` (DEV-781)
 - Tenant feature flag `notifySupervisorsOnBooking` toggle in booking settings
 - Overridable mail snippet `supervisor-booking-notification` in tenant mail configuration
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Fixed
 
 - Bundle checkout: payment step is shown when additional bookables require payment, even if the lead bookable is free via role discount (DEV-781)
+- Bundle checkout: payment step no longer appears when the discounted checkout total is zero (DEV-781)
 - Tenant feature flag `notifySupervisorsOnBooking` toggle in booking settings
 - Overridable mail snippet `supervisor-booking-notification` in tenant mail configuration
 

--- a/src/components/Bookable/BookableEdit.vue
+++ b/src/components/Bookable/BookableEdit.vue
@@ -96,6 +96,7 @@ import BookableEditBookingType from "@/components/Bookable/Edit/BookableEditBook
 import SaveBar from "@/components/commons/SaveBar.vue";
 import Bookable from "@/entities/bookable";
 import { normalizeLeadTimeFields } from "@/utils/bookingLeadTime";
+import { normalizeBookingDiscounts } from "@/utils/bookingDiscounts";
 import { mapActions, mapGetters } from "vuex";
 import BookableEditOpeningHours from "@/components/Bookable/Edit/BookableEditOpeningHours.vue";
 import BookableEditLockerSystems from "@/components/Bookable/Edit/BookableEditLockerSystems.vue";
@@ -242,7 +243,9 @@ export default {
         const response = await ApiBookablesService.createOrUpdateBookable(
           this.bookable
         );
-        this.bookable = normalizeLeadTimeFields(_.cloneDeep(response.data));
+        this.bookable = normalizeBookingDiscounts(
+          normalizeLeadTimeFields(_.cloneDeep(response.data))
+        );
 
         if (!this.bookableID) {
           this.$router.replace({
@@ -288,6 +291,7 @@ export default {
         this.bookable = normalizeLeadTimeFields(
           new Bookable(response.data).toPlain()
         );
+        normalizeBookingDiscounts(this.bookable);
         this.bookable.type = this.type;
       }
 
@@ -302,7 +306,9 @@ export default {
       try {
         this.isLoading = true;
         const response = await ApiBookablesService.getBookable(bookableId);
-        this.bookable = normalizeLeadTimeFields(_.cloneDeep(response.data));
+        this.bookable = normalizeBookingDiscounts(
+          normalizeLeadTimeFields(_.cloneDeep(response.data))
+        );
       } catch (err) {
         console.error("Error fetching bookable:", err);
       } finally {

--- a/src/components/Bookable/Edit/BookableEditPermissions.vue
+++ b/src/components/Bookable/Edit/BookableEditPermissions.vue
@@ -1,11 +1,15 @@
 <script>
 import BaseSection from "@/components/commons/BaseSection.vue";
 import ApiRolesService from "@/services/api/ApiRolesService";
+import ApiTenantService from "@/services/api/ApiTenantService";
 import UserRoleSelector from "@/components/commons/UserRoleSelector.vue";
+import BookingDiscountEditor from "@/components/Bookable/Edit/BookingDiscountEditor.vue";
+import { normalizeBookingDiscounts } from "@/utils/bookingDiscounts";
+import { mapGetters } from "vuex";
 
 export default {
   name: "BookableEditPermissions",
-  components: { UserRoleSelector, BaseSection },
+  components: { BookingDiscountEditor, UserRoleSelector, BaseSection },
   props: { bookable: { type: Object, required: true } },
   data() {
     return {
@@ -15,6 +19,12 @@ export default {
     };
   },
   computed: {
+    ...mapGetters({
+      currentTenantId: "tenants/currentTenantId",
+    }),
+    tenantId() {
+      return this.model.tenantId || this.currentTenantId;
+    },
     model: {
       get() {
         return this.bookable;
@@ -23,8 +33,17 @@ export default {
         this.$emit("update:bookable", { ...val });
       },
     },
+    availableUserIds() {
+      return this.availableUsers.map((user) => user.userId);
+    },
   },
   watch: {
+    bookable: {
+      immediate: true,
+      handler() {
+        this.ensureBookingDiscounts();
+      },
+    },
     "model.isBlockPeriodRelated": {
       immediate: true,
       handler(enabled) {
@@ -33,8 +52,19 @@ export default {
         }
       },
     },
+    tenantId() {
+      this.fetchUsers();
+    },
   },
   methods: {
+    ensureBookingDiscounts() {
+      const hadDiscounts = !!this.model.bookingDiscounts;
+      normalizeBookingDiscounts(this.model);
+
+      if (!hadDiscounts && this.model.bookingDiscounts) {
+        this.$set(this.model, "bookingDiscounts", this.model.bookingDiscounts);
+      }
+    },
     removePermittedUser(item) {
       this.model.permittedUsers.splice(
         this.model.permittedUsers.indexOf(item),
@@ -47,21 +77,9 @@ export default {
         1
       );
     },
-    removeFreeBookingUser(item) {
-      this.model.freeBookingUsers.splice(
-        this.model.freeBookingUsers.indexOf(item),
-        1
-      );
-    },
     removeGroupBookingRole(item) {
       this.model.groupBooking.permittedRoles.splice(
         this.model.groupBooking.permittedRoles.indexOf(item),
-        1
-      );
-    },
-    removeFreeBookingRole(item) {
-      this.model.freeBookingRoles.splice(
-        this.model.freeBookingRoles.indexOf(item),
         1
       );
     },
@@ -70,9 +88,50 @@ export default {
         this.availableRoles = result?.data;
       });
     },
+    async fetchUsers() {
+      if (!this.tenantId) {
+        this.availableUsers = [];
+        return;
+      }
+
+      try {
+        const response = await ApiTenantService.getTenantUsers(this.tenantId);
+        const userDetails = response.userDetails || [];
+
+        this.availableUsers = (response.users || [])
+          .map((user) => {
+            const details = userDetails.find((detail) => detail.id === user.userId);
+            const firstName = details?.firstName || user.firstName || "";
+            const lastName = details?.lastName || user.lastName || "";
+            const fullName = `${firstName} ${lastName}`.trim();
+
+            return {
+              userId: user.userId,
+              firstName,
+              lastName,
+              fullName: fullName || user.userId,
+              hasName: !!fullName,
+            };
+          })
+          .filter((user) => !!user.userId);
+      } catch (error) {
+        console.error("Error fetching tenant users:", error);
+        this.availableUsers = [];
+      }
+    },
+    async validate() {
+      return this.$refs.form ? this.$refs.form.validate() : true;
+    },
+    resetValidation() {
+      this.$refs.form?.resetValidation();
+    },
+  },
+  created() {
+    this.ensureBookingDiscounts();
   },
   mounted() {
     this.fetchRoles();
+    this.fetchUsers();
     if (!this.model.cancellationPolicy) {
       this.model.cancellationPolicy = { userCancellable: true };
     }
@@ -116,7 +175,7 @@ export default {
         <UserRoleSelector
           :users="model.permittedUsers"
           :roles="model.permittedRoles"
-          :available-users="availableUsers"
+          :available-users="availableUserIds"
           :available-roles-prop="availableRoles"
           :fetch-roles-on-mount="false"
           @update:users="model.permittedUsers = $event"
@@ -129,90 +188,30 @@ export default {
       </v-card-text>
     </v-card>
 
-    <v-card class="mb-6 section-card" elevation="2" outlined>
-      <v-card-title class="section-header pa-4">
-        <v-icon class="mr-2">mdi-ticket-percent-outline</v-icon>
-        <span class="text-h6 font-weight-bold">Kostenfreie Buchungen</span>
-      </v-card-title>
-      <v-divider></v-divider>
-      <v-card-text class="pa-4">
-        <div class="info-label mb-3">
-          <v-icon small class="mr-2">mdi-account-multiple</v-icon>
-          Kostenfrei für Benutzer
-        </div>
-        <p class="mb-3 text-caption">
-          Berechtigen Sie Nutzer dieses Objekt kostenfrei zu buchen.
-        </p>
-        <v-combobox
-          v-model="model.freeBookingUsers"
-          :items="availableUsers"
-          label="Kostenfrei für Benutzer"
-          hide-selected
-          no-data-text="Keine Benutzer verfügbar"
-          multiple
-          background-color="accent"
-          clearable
-          chips
-          filled
-          dense
-        >
-          <template v-slot:selection="{ attrs, item, select, selected }">
-            <v-chip
-              v-bind="attrs"
-              :input-value="selected"
-              close
-              small
-              color="secondary"
-              @click="select"
-              @click:close="removeFreeBookingUser(item)"
-            >
-              <strong>{{ item }}</strong>
-            </v-chip>
-          </template>
-        </v-combobox>
+    <BaseSection title="Preisrabatte" icon="mdi-ticket-percent-outline" />
 
-        <div class="info-label mb-3 mt-5">
-          <v-icon small class="mr-2">mdi-account-group</v-icon>
-          Kostenfrei für Rollen
-        </div>
-        <p class="mb-3 text-caption">
-          Berechtigen Sie <strong>alle Benutzer einer Rolle</strong>, dieses
-          Objekt kostenfrei zu buchen.
-        </p>
-        <v-combobox
-          v-model="model.freeBookingRoles"
-          :items="availableRoles"
-          label="Kostenfrei für Rollen"
-          item-text="name"
-          item-value="id"
-          hide-selected
-          no-data-text="Keine Rollen verfügbar"
-          multiple
-          background-color="accent"
-          clearable
-          chips
-          filled
-          dense
-          :return-object="false"
-        >
-          <template v-slot:selection="{ attrs, item, select, selected }">
-            <v-chip
-              v-bind="attrs"
-              :input-value="selected"
-              close
-              small
-              color="secondary"
-              @click="select"
-              @click:close="removeFreeBookingRole(item)"
-            >
-              <strong>{{
-                availableRoles.find((r) => r.id === item)?.name
-              }}</strong>
-            </v-chip>
-          </template>
-        </v-combobox>
-      </v-card-text>
-    </v-card>
+    <p class="mb-4 text-caption" style="max-width: 700px">
+      Legen Sie einen prozentualen Preisnachlass (0–100&nbsp;%) pro Benutzer
+      oder Rolle fest. 100&nbsp;% entspricht einer kostenfreien Buchung.
+    </p>
+
+    <BookingDiscountEditor
+      v-if="model.bookingDiscounts"
+      :items="model.bookingDiscounts.users"
+      type="user"
+      :available-users="availableUsers"
+      label="Rabatt für Benutzer"
+      hint="Gewähren Sie <strong>bestimmten Benutzern</strong> einen Preisnachlass auf dieses Buchungsobjekt."
+    />
+
+    <BookingDiscountEditor
+      v-if="model.bookingDiscounts"
+      :items="model.bookingDiscounts.roles"
+      type="role"
+      :available-roles="availableRoles"
+      label="Rabatt für Rollen"
+      hint="Gewähren Sie <strong>allen Benutzern einer Rolle</strong> einen Preisnachlass auf dieses Buchungsobjekt."
+    />
 
     <v-card class="mb-6 section-card" elevation="2" outlined>
       <v-card-title class="section-header pa-4">
@@ -316,8 +315,8 @@ export default {
           v-model="model.cancellationPolicy.userCancellable"
         ></v-switch>
         <p class="mb-0 mt-3 text-caption" style="max-width: 700px">
-          Wenn aktiviert, können Benutzer ihre eigenen Buchungen stornieren. Andernfalls ist eine Stornierung nur durch
-          Administratoren möglich.
+          Wenn aktiviert, können Benutzer ihre eigenen Buchungen stornieren.
+          Andernfalls ist eine Stornierung nur durch Administratoren möglich.
         </p>
       </v-card-text>
     </v-card>

--- a/src/components/Bookable/Edit/BookingDiscountEditor.vue
+++ b/src/components/Bookable/Edit/BookingDiscountEditor.vue
@@ -1,0 +1,449 @@
+<script>
+export default {
+  name: "BookingDiscountEditor",
+  props: {
+    items: {
+      type: Array,
+      default: () => [],
+    },
+    type: {
+      type: String,
+      required: true,
+      validator: (value) => ["user", "role"].includes(value),
+    },
+    availableRoles: {
+      type: Array,
+      default: () => [],
+    },
+    availableUsers: {
+      type: Array,
+      default: () => [],
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    hint: {
+      type: String,
+      default: "",
+    },
+  },
+  data() {
+    return {
+      showAddDialog: false,
+      newEntryId: null,
+      newEntryPercent: 100,
+      addFormValid: true,
+    };
+  },
+  computed: {
+    idKey() {
+      return this.type === "user" ? "userId" : "roleId";
+    },
+    icon() {
+      return this.type === "user"
+        ? "mdi-account-multiple"
+        : "mdi-account-group";
+    },
+    dialogTitle() {
+      return this.type === "user"
+        ? "Benutzer-Rabatt hinzufügen"
+        : "Rollen-Rabatt hinzufügen";
+    },
+    emptyTitle() {
+      return this.type === "user"
+        ? "Noch keine Benutzer-Rabatte definiert"
+        : "Noch keine Rollen-Rabatte definiert";
+    },
+    emptyDescription() {
+      return this.type === "user"
+        ? "Gewähren Sie bestimmten Benutzern einen Preisnachlass auf dieses Buchungsobjekt."
+        : "Gewähren Sie allen Benutzern einer Rolle einen Preisnachlass auf dieses Buchungsobjekt.";
+    },
+    emptyCta() {
+      return this.type === "user"
+        ? "Ersten Benutzer-Rabatt hinzufügen"
+        : "Ersten Rollen-Rabatt hinzufügen";
+    },
+    addSelectLabel() {
+      return this.type === "user" ? "Benutzer" : "Rolle";
+    },
+    discountRules() {
+      return [
+        (value) =>
+          (value !== "" && value !== null && value !== undefined) ||
+          "Pflichtfeld",
+        (value) => Number.isInteger(Number(value)) || "Ganzzahl erforderlich",
+        (value) =>
+          (value >= 0 && value <= 100) ||
+          "Wert muss zwischen 0 und 100 liegen",
+      ];
+    },
+    idRules() {
+      return [(value) => !!value || "Pflichtfeld"];
+    },
+    safeItems() {
+      return (this.items || []).filter(
+        (entry) => entry && typeof entry === "object"
+      );
+    },
+    assignedIds() {
+      return this.safeItems
+        .map((entry) => entry[this.idKey])
+        .filter((id) => id !== null && id !== undefined && id !== "");
+    },
+    availableToAdd() {
+      if (this.type === "user") {
+        return this.availableUsers.filter(
+          (user) => !this.assignedIds.includes(user.userId)
+        );
+      }
+
+      return this.availableRoles.filter(
+        (role) => !this.assignedIds.includes(role.id)
+      );
+    },
+    canAddMore() {
+      return this.availableToAdd.length > 0;
+    },
+    canConfirmAdd() {
+      return (
+        !!this.newEntryId &&
+        Number.isInteger(Number(this.newEntryPercent)) &&
+        this.newEntryPercent >= 0 &&
+        this.newEntryPercent <= 100 &&
+        !this.assignedIds.includes(this.newEntryId)
+      );
+    },
+  },
+  methods: {
+    getUserById(userId) {
+      return this.availableUsers.find((user) => user.userId === userId);
+    },
+    displayName(entry) {
+      if (this.type === "user") {
+        const user = this.getUserById(entry.userId);
+        if (user?.hasName) {
+          return user.fullName;
+        }
+
+        return entry.userId || "Benutzer";
+      }
+
+      return (
+        this.availableRoles.find((role) => role.id === entry.roleId)?.name ||
+        "Rolle"
+      );
+    },
+    displayEmail(entry) {
+      if (this.type !== "user") {
+        return null;
+      }
+
+      const user = this.getUserById(entry.userId);
+      if (user?.hasName) {
+        return user.userId;
+      }
+
+      return null;
+    },
+    discountLabel(percent) {
+      if (percent >= 100) {
+        return "100 % (kostenfrei)";
+      }
+
+      return `${percent} %`;
+    },
+    openAddDialog() {
+      if (!this.canAddMore) {
+        return;
+      }
+
+      this.newEntryId = null;
+      this.newEntryPercent = 100;
+      this.showAddDialog = true;
+      this.$nextTick(() => {
+        this.$refs.addForm?.resetValidation();
+      });
+    },
+    cancelAdd() {
+      this.showAddDialog = false;
+      this.newEntryId = null;
+      this.newEntryPercent = 100;
+      this.$refs.addForm?.resetValidation();
+    },
+    async confirmAdd() {
+      if (!this.$refs.addForm?.validate() || !this.canConfirmAdd) {
+        return;
+      }
+
+      if (!Array.isArray(this.items)) {
+        return;
+      }
+
+      this.items.push({
+        [this.idKey]: this.newEntryId,
+        discountPercent: Number(this.newEntryPercent),
+      });
+
+      this.cancelAdd();
+    },
+    removeEntry(index) {
+      const entry = this.safeItems[index];
+      if (!entry || !Array.isArray(this.items)) {
+        return;
+      }
+
+      const originalIndex = this.items.indexOf(entry);
+      if (originalIndex !== -1) {
+        this.items.splice(originalIndex, 1);
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <v-card class="mb-6 section-card" elevation="2" outlined>
+    <v-card-title
+      class="section-header pa-4 d-flex justify-space-between align-center"
+    >
+      <div>
+        <v-icon class="mr-2">{{ icon }}</v-icon>
+        <span class="text-h6 font-weight-bold">{{ label }}</span>
+      </div>
+      <v-btn
+        small
+        color="primary"
+        :disabled="!canAddMore"
+        @click="openAddDialog"
+      >
+        <v-icon left small>mdi-plus</v-icon>
+        Hinzufügen
+      </v-btn>
+    </v-card-title>
+    <v-divider />
+
+    <v-card-text class="pa-4">
+      <p
+        v-if="hint"
+        class="mb-4 text-caption"
+        style="max-width: 700px"
+        v-html="hint"
+      />
+
+      <div v-if="safeItems.length > 0">
+        <v-list class="py-0">
+          <template v-for="(entry, index) in safeItems">
+            <v-list-item :key="`${type}-discount-${index}`" class="px-0">
+              <v-list-item-avatar class="mr-3" color="accent" size="36">
+                <v-icon small>{{ icon }}</v-icon>
+              </v-list-item-avatar>
+
+              <v-list-item-content>
+                <v-list-item-title class="font-weight-medium">
+                  {{ displayName(entry) }}
+                </v-list-item-title>
+                <v-list-item-subtitle
+                  v-if="displayEmail(entry)"
+                  class="text-caption grey--text text--darken-1"
+                >
+                  {{ displayEmail(entry) }}
+                </v-list-item-subtitle>
+                <v-list-item-subtitle>
+                  <v-chip
+                    x-small
+                    :color="
+                      entry.discountPercent >= 100 ? 'success' : 'primary'
+                    "
+                    text-color="white"
+                    class="mt-1"
+                  >
+                    {{ discountLabel(entry.discountPercent) }}
+                  </v-chip>
+                </v-list-item-subtitle>
+              </v-list-item-content>
+
+              <v-list-item-content class="discount-field-col">
+                <v-text-field
+                  v-model.number="entry.discountPercent"
+                  label="Rabatt"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  suffix="%"
+                  hide-details="auto"
+                  background-color="accent"
+                  filled
+                  dense
+                  :rules="discountRules"
+                />
+              </v-list-item-content>
+
+              <v-list-item-action title="Entfernen">
+                <v-btn icon small @click="removeEntry(index)">
+                  <v-icon color="grey lighten-1">mdi-close</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+
+            <v-divider
+              v-if="index < safeItems.length - 1"
+              :key="`${type}-divider-${index}`"
+            />
+          </template>
+        </v-list>
+      </div>
+
+      <div v-else class="text-center py-8">
+        <v-icon large color="grey lighten-1" class="mb-2">
+          {{ icon }}
+        </v-icon>
+        <div class="text-h6 grey--text mb-2">
+          {{ emptyTitle }}
+        </div>
+        <div class="text-body-2 grey--text text--darken-1 mb-4">
+          {{ emptyDescription }}
+        </div>
+        <v-btn
+          small
+          text
+          color="primary"
+          :disabled="!canAddMore"
+          @click="openAddDialog"
+        >
+          <v-icon left small>mdi-plus</v-icon>
+          {{ emptyCta }}
+        </v-btn>
+      </div>
+    </v-card-text>
+
+    <v-dialog v-model="showAddDialog" max-width="520px" persistent>
+      <v-form ref="addForm" v-model="addFormValid">
+        <v-card>
+          <div class="px-6 py-5 d-flex align-center">
+            <v-icon large class="mr-3">mdi-plus-circle</v-icon>
+            <span class="text-h5 font-weight-bold">{{ dialogTitle }}</span>
+          </div>
+
+          <v-divider />
+
+          <v-card-text class="px-6 py-6">
+            <v-autocomplete
+              v-if="type === 'user'"
+              v-model="newEntryId"
+              :items="availableToAdd"
+              :label="addSelectLabel"
+              item-text="fullName"
+              item-value="userId"
+              hide-details="auto"
+              background-color="accent"
+              filled
+              dense
+              clearable
+              no-data-text="Keine Benutzer verfügbar"
+              :rules="idRules"
+            >
+              <template #item="{ item }">
+                <v-list-item-content>
+                  <v-list-item-title>{{ item.fullName }}</v-list-item-title>
+                  <v-list-item-subtitle
+                    v-if="item.hasName"
+                    class="text-caption grey--text"
+                  >
+                    {{ item.userId }}
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </template>
+              <template #selection="{ item }">
+                <span>{{ item.fullName }}</span>
+              </template>
+            </v-autocomplete>
+            <v-select
+              v-else
+              v-model="newEntryId"
+              :items="availableToAdd"
+              :label="addSelectLabel"
+              item-text="name"
+              item-value="id"
+              hide-details="auto"
+              background-color="accent"
+              filled
+              dense
+              clearable
+              no-data-text="Keine Rollen verfügbar"
+              :rules="idRules"
+            />
+
+            <v-text-field
+              v-model.number="newEntryPercent"
+              class="mt-4"
+              label="Rabatt"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              suffix="%"
+              hide-details="auto"
+              background-color="accent"
+              filled
+              dense
+              :rules="discountRules"
+            />
+
+            <p class="mb-0 mt-4 text-caption text--secondary">
+              100&nbsp;% entspricht einer kostenfreien Buchung für die
+              ausgewählte {{ type === "user" ? "Person" : "Rolle" }}.
+            </p>
+          </v-card-text>
+
+          <v-divider />
+
+          <v-card-actions class="px-6 py-4">
+            <v-spacer />
+            <v-btn text @click="cancelAdd">Abbrechen</v-btn>
+            <v-btn
+              color="primary"
+              :disabled="!canConfirmAdd"
+              @click="confirmAdd"
+            >
+              Übernehmen
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-form>
+    </v-dialog>
+  </v-card>
+</template>
+
+<style scoped>
+.section-card {
+  border-radius: 8px !important;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
+}
+.section-header {
+  background: linear-gradient(
+    135deg,
+    rgba(0, 0, 0, 0.02) 0%,
+    rgba(0, 0, 0, 0.01) 100%
+  );
+}
+.theme--dark .section-header {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+}
+.discount-field-col {
+  max-width: 140px;
+  flex: 0 0 140px;
+}
+@media (max-width: 959px) {
+  .discount-field-col {
+    max-width: none;
+    flex: 1 1 auto;
+  }
+}
+</style>

--- a/src/entities/bookable.js
+++ b/src/entities/bookable.js
@@ -1,3 +1,5 @@
+import { normalizeBookingDiscounts } from "@/utils/bookingDiscounts";
+
 export default class Bookable {
   constructor(overrides = {}) {
     this.id = "";
@@ -54,8 +56,10 @@ export default class Bookable {
 
     this.permittedUsers = [];
     this.permittedRoles = [];
-    this.freeBookingUsers = [];
-    this.freeBookingRoles = [];
+    this.bookingDiscounts = {
+      users: [],
+      roles: [],
+    };
 
     this.relatedBookableIds = [];
     this.checkoutBookableIds = [];
@@ -72,6 +76,7 @@ export default class Bookable {
     this.externalProviders = [];
 
     Object.assign(this, overrides);
+    normalizeBookingDiscounts(this);
   }
 
   toPlain() {

--- a/src/services/api/ApiCheckoutService.js
+++ b/src/services/api/ApiCheckoutService.js
@@ -5,7 +5,7 @@ export default {
     timeBegin,
     timeEnd,
     couponCode,
-    bookWithPrice,
+    bookWithoutDiscount,
     checkoutID
   ) {
 
@@ -15,7 +15,7 @@ export default {
       timeBegin,
       timeEnd,
       couponCode,
-      bookWithPrice,
+      bookWithoutDiscount,
       checkoutId: checkoutID,
     });
   },

--- a/src/store/modules/bookables.js
+++ b/src/store/modules/bookables.js
@@ -59,8 +59,10 @@ const state = {
     requiresLogin: false,
     permittedUsers: [],
     permittedRoles: [],
-    freeBookingUsers: [],
-    freeBookingRoles: [],
+    bookingDiscounts: {
+      users: [],
+      roles: [],
+    },
     relatedBookableIds: [],
     checkoutBookableIds: [],
 
@@ -160,8 +162,10 @@ const mutations = {
 
       permittedUsers: [],
       permittedRoles: [],
-      freeBookingUsers: [],
-      freeBookingRoles: [],
+      bookingDiscounts: {
+        users: [],
+        roles: [],
+      },
       relatedBookableIds: [],
       checkoutBookableIds: [],
 

--- a/src/utils/bookingDiscounts.js
+++ b/src/utils/bookingDiscounts.js
@@ -1,0 +1,64 @@
+function sanitizeUserDiscounts(entries) {
+  return (entries || [])
+    .filter((entry) => entry && typeof entry === "object")
+    .map((entry) => ({
+      userId: entry.userId ?? "",
+      discountPercent: Number.isInteger(entry.discountPercent)
+        ? entry.discountPercent
+        : 100,
+    }));
+}
+
+function sanitizeRoleDiscounts(entries) {
+  return (entries || [])
+    .filter((entry) => entry && typeof entry === "object")
+    .map((entry) => ({
+      roleId: entry.roleId ?? null,
+      discountPercent: Number.isInteger(entry.discountPercent)
+        ? entry.discountPercent
+        : 100,
+    }));
+}
+
+export function normalizeBookingDiscounts(bookable) {
+  if (!bookable || typeof bookable !== "object") {
+    return bookable;
+  }
+
+  const usersFromLegacy = (bookable.freeBookingUsers || []).map((userId) => ({
+    userId,
+    discountPercent: 100,
+  }));
+  const rolesFromLegacy = (bookable.freeBookingRoles || []).map((roleId) => ({
+    roleId,
+    discountPercent: 100,
+  }));
+
+  if (!bookable.bookingDiscounts) {
+    bookable.bookingDiscounts = {
+      users: usersFromLegacy,
+      roles: rolesFromLegacy,
+    };
+  } else {
+    const discounts = bookable.bookingDiscounts;
+    const users = sanitizeUserDiscounts(discounts.users);
+    const roles = sanitizeRoleDiscounts(discounts.roles);
+
+    discounts.users =
+      users.length > 0 ? users : usersFromLegacy;
+    discounts.roles =
+      roles.length > 0 ? roles : rolesFromLegacy;
+  }
+
+  delete bookable.freeBookingUsers;
+  delete bookable.freeBookingRoles;
+
+  return bookable;
+}
+
+export function createEmptyBookingDiscounts() {
+  return {
+    users: [],
+    roles: [],
+  };
+}

--- a/src/views/BundleCheckout/CheckoutMain.vue
+++ b/src/views/BundleCheckout/CheckoutMain.vue
@@ -373,12 +373,8 @@ export default {
         return false;
       }
 
-      const allItems = [this.leadItem, ...this.subsequentItems];
-
-      return allItems.some(
-        (item) =>
-          (item.userPriceEur ?? 0) > 0 ||
-          item.bookable?.priceCategories?.some((pC) => pC.priceEur > 0)
+      return [this.leadItem, ...this.subsequentItems].some(
+        (item) => (item.userPriceEur ?? 0) > 0
       );
     },
 

--- a/src/views/BundleCheckout/CheckoutMain.vue
+++ b/src/views/BundleCheckout/CheckoutMain.vue
@@ -54,15 +54,15 @@
               :checkout-id="checkoutId"
               :final-check="step === steps.length"
               :me="me"
-              :free-booking-allowed="
-                step === steps.length ? false : leadItem.freeBookingAllowed
+              :booking-discount-percent="
+                step === steps.length ? 0 : leadItem.bookingDiscountPercent
               "
-              :initial-book-with-price="bookWithPrice"
+              :initial-book-without-discount="bookWithoutDiscount"
               @back="previousPage()"
               @validate-items="validateItems()"
               @redeem-coupon="redeemCoupon"
               @remove-coupon="removeCoupon"
-              @set-book-with-price="setBookWithPrice"
+              @set-book-without-discount="setBookWithoutDiscount"
             ></checkout-quick-summary>
           </v-col>
         </v-row>
@@ -128,6 +128,7 @@ export default {
         regularGrossPriceEur: null,
         userGrossPriceEur: null,
         freeBookingAllowed: false,
+        bookingDiscountPercent: 0,
       },
       subsequentItems: [],
       timeBegin: null,
@@ -148,7 +149,7 @@ export default {
       activePaymentApps: [],
       selectedPaymentApp: null,
       allowSeriesFlag: false,
-      bookWithPrice: false,
+      bookWithoutDiscount: false,
     };
   },
 
@@ -368,7 +369,10 @@ export default {
     },
 
     shouldShowPaymentStep() {
-      if (this.leadItem.freeBookingAllowed && !this.bookWithPrice) {
+      if (
+        this.leadItem.bookingDiscountPercent >= 100 &&
+        !this.bookWithoutDiscount
+      ) {
         return false;
       }
 
@@ -392,6 +396,7 @@ export default {
         regularGrossPriceEur: null,
         userGrossPriceEur: null,
         freeBookingAllowed: false,
+        bookingDiscountPercent: 0,
       };
       this.subsequentItems = [];
       this.timeBegin = null;
@@ -516,7 +521,7 @@ export default {
               this.timeBegin,
               this.timeEnd,
               this.coupon?.id,
-              this.bookWithPrice,
+              this.bookWithoutDiscount,
               this.checkoutId
             );
 
@@ -531,6 +536,8 @@ export default {
               item.valid = true;
               item.freeBookingAllowed =
                 response.data.freeBookingAllowed || false;
+              item.bookingDiscountPercent =
+                response.data.bookingDiscountPercent || 0;
 
               delete item.error;
             }
@@ -543,6 +550,7 @@ export default {
             item.regularGrossPriceEur = null;
             item.userGrossPriceEur = null;
             item.freeBookingAllowed = false;
+            item.bookingDiscountPercent = 0;
 
             item.valid = false;
             item.error = formatCheckoutValidationError(error.response?.data);
@@ -694,8 +702,8 @@ export default {
         console.log("Error while fetching user roles", error);
       }
     },
-    async setBookWithPrice(value) {
-      this.bookWithPrice = value;
+    async setBookWithoutDiscount(value) {
+      this.bookWithoutDiscount = value;
       await this.validateItems();
     },
 

--- a/src/views/BundleCheckout/CheckoutMain.vue
+++ b/src/views/BundleCheckout/CheckoutMain.vue
@@ -369,18 +369,16 @@ export default {
     },
 
     shouldShowPaymentStep() {
-      if (
-        this.leadItem.bookingDiscountPercent >= 100 &&
-        !this.bookWithoutDiscount
-      ) {
+      if (this.activePaymentApps.length <= 1 || !this.leadItem.bookable) {
         return false;
       }
 
-      return (
-        this.activePaymentApps.length > 1 &&
-        this.leadItem.bookable &&
-        (this.leadItem.bookable.priceCategories.some((pC) => pC.priceEur > 0) ||
-          this.leadItem.userPriceEur > 0)
+      const allItems = [this.leadItem, ...this.subsequentItems];
+
+      return allItems.some(
+        (item) =>
+          (item.userPriceEur ?? 0) > 0 ||
+          item.bookable?.priceCategories?.some((pC) => pC.priceEur > 0)
       );
     },
 

--- a/src/views/BundleCheckout/CheckoutQuickSummary.vue
+++ b/src/views/BundleCheckout/CheckoutQuickSummary.vue
@@ -271,16 +271,15 @@
       </v-card-text>
     </v-card>
 
-    <v-card class="mt-5 rounded-sm" outlined v-if="freeBookingAllowed">
+    <v-card class="mt-5 rounded-sm" outlined v-if="showDiscountOption">
       <v-card-text>
-        <strong>Kostenfreie Buchung</strong> Sie sind berechtigt, diese Buchung
-        kostenfrei abzuschließen. Wenn Sie dennoch eine kostenpflichtige Buchung
-        wünschen, können Sie dies tun, indem Sie den Schalter unten aktivieren.
+        <strong>{{ discountCardTitle }}</strong>
+        {{ discountCardText }}
 
         <v-switch
-          v-model="bookWithPrice"
-          @change="setBookWithPrice($event)"
-          label="Kostenpflichtig buchen"
+          v-model="bookWithoutDiscount"
+          @change="setBookWithoutDiscount($event)"
+          label="Zum vollen Preis buchen"
           class="mt-4"
         >
         </v-switch>
@@ -365,11 +364,11 @@ export default {
     selectedPaymentApp: {
       type: String,
     },
-    freeBookingAllowed: {
-      type: Boolean,
-      default: false,
+    bookingDiscountPercent: {
+      type: Number,
+      default: 0,
     },
-    initialBookWithPrice: {
+    initialBookWithoutDiscount: {
       type: Boolean,
       default: false,
     },
@@ -380,8 +379,14 @@ export default {
       validating: false,
       isSubmitting: false,
       couponCode: null,
-      bookWithPrice: this.initialBookWithPrice,
+      bookWithoutDiscount: this.initialBookWithoutDiscount,
     };
+  },
+
+  watch: {
+    initialBookWithoutDiscount(value) {
+      this.bookWithoutDiscount = value;
+    },
   },
 
   methods: {
@@ -389,10 +394,10 @@ export default {
       addToast: "toasts/add",
     }),
     isTimeDependentBookable,
-    setBookWithPrice(value) {
-      this.bookWithPrice = value;
-      this.$emit("update:initialBookWithPrice", value);
-      this.$emit("set-book-with-price", value);
+    setBookWithoutDiscount(value) {
+      this.bookWithoutDiscount = value;
+      this.$emit("update:initialBookWithoutDiscount", value);
+      this.$emit("set-book-without-discount", value);
     },
 
     dateToLocaleString: function (value) {
@@ -494,7 +499,7 @@ export default {
               };
             })
         ),
-        bookWithPrice: this.bookWithPrice,
+        bookWithoutDiscount: this.bookWithoutDiscount,
       };
     },
 
@@ -606,6 +611,23 @@ export default {
   },
 
   computed: {
+    showDiscountOption() {
+      return this.bookingDiscountPercent > 0;
+    },
+    discountCardTitle() {
+      if (this.bookingDiscountPercent >= 100) {
+        return "Kostenfreie Buchung:";
+      }
+
+      return "Preisnachlass:";
+    },
+    discountCardText() {
+      if (this.bookingDiscountPercent >= 100) {
+        return " Sie sind berechtigt, diese Buchung kostenfrei abzuschließen. Wenn Sie dennoch eine kostenpflichtige Buchung wünschen, können Sie den Schalter unten aktivieren.";
+      }
+
+      return ` Sie erhalten einen Preisnachlass von ${this.bookingDiscountPercent} % auf diese Buchung. Wenn Sie dennoch zum vollen Preis buchen möchten, aktivieren Sie den Schalter unten.`;
+    },
     totalPrice() {
       let price = 0;
       for (const item of [this.leadItem, ...this.subsequentItems]) {


### PR DESCRIPTION
## Summary
- Replace binary `freeBookingUsers` / `freeBookingRoles` on bookables with `bookingDiscounts` (0–100 % per user or role) in the Admin UI
- Add dialog-based discount editor with tenant member display (name + email)
- Update bundle checkout to use `bookingDiscountPercent` and `bookWithoutDiscount` instead of `bookWithPrice`

## Test plan
- [x] Open a bookable → Berechtigungen → configure user and role discounts (e.g. 50 %, 100 %)
- [x] Save bookable and verify `bookingDiscounts` is persisted via API
- [x] Run checkout as a user with partial discount → reduced price shown, payment step when price > 0
- [x] Run checkout as a user with 100 % discount → free booking card, no payment step by default
- [x] Toggle "Zum vollen Preis buchen" → full price applied, `bookWithoutDiscount: true` in requests
- [x] Verify existing migrated bookables show 100 % discounts correctly after backend migration