### PR TITLE
feat(DEV-786): cancellation refund tiers and admin workflows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,11 +14,18 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Admin UI for supervisor booking notifications (DEV-779): manage `bookingNotificationRecipients` per tenant member (user, role, email; max. 10) in the member detail dialog
 - Bookable permissions: per-user and per-role booking discounts with percentage field (0–100) replace the previous free-booking lists (DEV-781)
 - Bundle checkout: role/user booking discounts shown via `bookingDiscountPercent`; opt-out uses `bookWithoutDiscount` instead of `bookWithPrice` (DEV-781)
+- Tenant cancellation refund tiers with policy previews, admin overrides, and per-booking series breakdowns (DEV-786)
+- Persisted cancellation refund audit on bookings with read-only display in booking details and edit views (DEV-786)
 
 ### Changed
 
 - Custom fields: simplified editor and list layout with live preview, clearer labels, and read-only inherited fields
 - Bookable edit: custom field values and definitions merged into a single „Eigene Felder“ tab
+- Cancelled bookings can be reactivated via the status switch in booking edit (DEV-786)
+
+### Fixed
+
+- Reactivating a cancelled booking no longer resets the booking price to 0 € (DEV-786)
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Series cancellation dialog accepts optional customer bank details for the aggregated cancellation PDF (and when cancelling only one booking from a series) (DEV-786)
 - Customer self-cancellation flow shows the expected refund (amount, percentage, fee) on the request and verify pages; cancellation mails and the `booking-cancel` snippet expose matching refund variables (DEV-786)
 - Series bookings in the Kanban board are now visually marked with a chip and accent border; the series can be opened directly from the card (DEV-626)
 - Booking overview filter for booking type: all, single bookings only, or series bookings only — accessible via filter button in the search field (DEV-626)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Customer self-cancellation flow shows the expected refund (amount, percentage, fee) on the request and verify pages; cancellation mails and the `booking-cancel` snippet expose matching refund variables (DEV-786)
 - Series bookings in the Kanban board are now visually marked with a chip and accent border; the series can be opened directly from the card (DEV-626)
 - Booking overview filter for booking type: all, single bookings only, or series bookings only — accessible via filter button in the search field (DEV-626)
 - Admin UI for supervisor booking notifications (DEV-779): manage `bookingNotificationRecipients` per tenant member (user, role, email; max. 10) in the member detail dialog

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Bundle checkout: role/user booking discounts shown via `bookingDiscountPercent`; opt-out uses `bookWithoutDiscount` instead of `bookWithPrice` (DEV-781)
 - Tenant cancellation refund tiers with policy previews, admin overrides, and per-booking series breakdowns (DEV-786)
 - Persisted cancellation refund audit on bookings with read-only display in booking details and edit views (DEV-786)
+- Cancellation PDF template editor: refund-tier Handlebars variables, backend-aligned default blocks, and „Standardvorlage laden“ in the visual editor (DEV-786)
 
 ### Changed
 

--- a/src/components/Booking/BookingDeleteConformationDialog.vue
+++ b/src/components/Booking/BookingDeleteConformationDialog.vue
@@ -14,19 +14,21 @@
       <v-card-actions>
         <v-spacer />
         <v-col class="shrink">
-          <v-tooltip :disabled="!isPayedAndHasPrice" top>
+          <v-tooltip :disabled="!isProtectedBooking" top>
             <template v-slot:activator="{ on }">
               <div v-on="on">
                 <v-btn
                   color="primary"
-                  :disabled="isPayedAndHasPrice"
+                  :disabled="isProtectedBooking"
                   :loading="inProgress"
                   @click="onDelete"
                   >Ja</v-btn
                 >
               </div>
             </template>
-            <span>Die Buchung wurde bereits bezahlt.</span>
+            <span>
+              Bestätigte oder bezahlte Buchungen müssen storniert werden.
+            </span>
           </v-tooltip>
         </v-col>
         <v-col class="shrink">
@@ -60,10 +62,8 @@ export default {
         return this.open;
       },
     },
-    isPayedAndHasPrice() {
-      return !!(
-        this.toDelete.isPayed && this.toDelete?._populated?.bookable?.priceEur
-      );
+    isProtectedBooking() {
+      return !!(this.toDelete.isCommitted || this.toDelete.isPayed);
     },
   },
   methods: {

--- a/src/components/Booking/BookingDetails.vue
+++ b/src/components/Booking/BookingDetails.vue
@@ -575,6 +575,11 @@
                 </v-alert>
               </v-col>
             </v-row>
+            <v-row v-if="cancellationRefundAudit">
+              <v-col cols="12">
+                <CancellationRefundAudit :audit="cancellationRefundAudit" />
+              </v-col>
+            </v-row>
           </v-card-text>
         </v-card>
 
@@ -1083,6 +1088,8 @@ import { getIfbsErrorMessage } from "@/utils/ifbsErrors";
 import ProcessingIndicator from "@/components/ProcessingIndicator.vue";
 import ProcessingService from "@/services/ProcessingService";
 import BookableTypeChip from "@/components/commons/BookableTypeChip.vue";
+import CancellationRefundAudit from "@/components/Booking/CancellationRefundAudit.vue";
+import { getCancellationRefundAudit } from "@/utils/cancellationRefund";
 import {
   getPaymentStatus,
   getPaymentStatusColor,
@@ -1096,6 +1103,7 @@ export default {
   name: "BookingDetails",
   components: {
     BookableTypeChip,
+    CancellationRefundAudit,
     ProcessingIndicator,
     GroupBookingCreateReceipt,
     GroupBookingCreateInvoice,
@@ -1152,6 +1160,9 @@ export default {
       return this.booking.attachments?.filter(
         (attachment) => attachment.type === "cancellation"
       );
+    },
+    cancellationRefundAudit() {
+      return getCancellationRefundAudit(this.booking);
     },
     attachments() {
       if (!this.booking.attachments) return [];

--- a/src/components/Booking/BookingEdit.vue
+++ b/src/components/Booking/BookingEdit.vue
@@ -1720,6 +1720,7 @@ export default {
       id,
       reason,
       skipCancellation,
+      bankDetails,
       refundPercentage
     ) {
       this.inProgress = true;
@@ -1730,6 +1731,7 @@ export default {
           this.groupBooking.id,
           reason,
           skipCancellation,
+          bankDetails,
           refundPercentage
         );
         if (!response.success) {

--- a/src/components/Booking/BookingEdit.vue
+++ b/src/components/Booking/BookingEdit.vue
@@ -22,7 +22,12 @@
         </div>
       </div>
 
-      <BookingEditStatus :booking="selectedBooking" />
+      <BookingEditStatus
+        :booking="selectedBooking"
+        :reject-dialog-open="openRejectDialog || openGroupRejectDialog"
+        @request-reject="openCancellationDialog"
+        @confirm-unreject="unrejectBooking"
+      />
       <v-row dense>
         <v-col cols="12" lg="9">
           <BaseSection title="Objekt & Zeitraum" icon="mdi-cube-outline">
@@ -850,6 +855,23 @@
       @submit="submitChanges"
       @cancel="resetChanges"
     />
+    <BookingRejectConformationDialog
+      :to-reject="selectedBooking"
+      :open="openRejectDialog"
+      :loading="inProgress"
+      @close="openRejectDialog = false"
+      @reject-booking="rejectBooking"
+    />
+    <GroupBookingRejectConformationDialog
+      :to-reject="selectedBooking"
+      :group-booking-id="groupBooking?.id"
+      :open="openGroupRejectDialog"
+      :in-progress="inProgress"
+      :error="rejectError"
+      @close="openGroupRejectDialog = false"
+      @reject-single-booking="rejectBooking"
+      @reject-group-booking="rejectGroupBooking"
+    />
   </div>
 </template>
 
@@ -877,11 +899,15 @@ import {
   validateRequiredCustomFields,
 } from "@/utils/bookingCustomFields";
 import ApiGroupBookingService from "@/services/api/ApiGroupBookingService";
+import BookingRejectConformationDialog from "@/components/Booking/BookingRejectConformationDialog.vue";
+import GroupBookingRejectConformationDialog from "@/components/Booking/GroupBookingRejectConformationDialog.vue";
 import _ from "lodash";
 
 export default {
   name: "BookingEdit",
   components: {
+    GroupBookingRejectConformationDialog,
+    BookingRejectConformationDialog,
     BookableTypeChip,
     BaseSection,
     SaveBar,
@@ -1026,11 +1052,15 @@ export default {
 
       editableBooking: null,
       originalSnapshot: null,
+      openRejectDialog: false,
+      openGroupRejectDialog: false,
+      rejectError: null,
     };
   },
   computed: {
     ...mapGetters({
       tenants: "tenants/tenants",
+      tenantId: "tenants/currentTenantId",
     }),
     isCreateMode() {
       return !this.selectedBooking.id;
@@ -1646,6 +1676,106 @@ export default {
         );
       }
       this.externalPricesMap = _.cloneDeep(snap.externalPrices || {});
+    },
+    openCancellationDialog() {
+      this.rejectError = null;
+      if (this.groupBooking?.id) {
+        this.openGroupRejectDialog = true;
+      } else {
+        this.openRejectDialog = true;
+      }
+    },
+    async rejectBooking(
+      id,
+      reason,
+      skipCancellation,
+      bankDetails,
+      refundPercentage
+    ) {
+      this.inProgress = true;
+      try {
+        await ApiBookingService.rejectBooking(
+          id,
+          this.tenantId,
+          reason,
+          skipCancellation,
+          bankDetails,
+          refundPercentage
+        );
+        await this.addToast(
+          ToastService.createToast("booking.reject.success", "success")
+        );
+        this.openRejectDialog = false;
+        this.openGroupRejectDialog = false;
+        this.finishSave();
+      } catch (error) {
+        await this.addToast(
+          ToastService.createToast("booking.reject.error", "error")
+        );
+      } finally {
+        this.inProgress = false;
+      }
+    },
+    async rejectGroupBooking(
+      id,
+      reason,
+      skipCancellation,
+      refundPercentage
+    ) {
+      this.inProgress = true;
+      this.rejectError = null;
+      try {
+        const response = await ApiGroupBookingService.rejectGroupBooking(
+          this.tenantId,
+          this.groupBooking.id,
+          reason,
+          skipCancellation,
+          refundPercentage
+        );
+        if (!response.success) {
+          this.rejectError = this.$t("group-booking.reject.error.message");
+          return;
+        }
+        await this.addToast(
+          ToastService.createToast("group-booking.reject.success", "success")
+        );
+        this.openGroupRejectDialog = false;
+        this.finishSave();
+      } catch (error) {
+        this.rejectError = this.$t("group-booking.reject.error.message");
+      } finally {
+        this.inProgress = false;
+      }
+    },
+    async unrejectBooking() {
+      if (!this.selectedBooking?.id) return;
+
+      this.inProgress = true;
+      try {
+        const response = await ApiBookingService.getBooking(
+          this.selectedBooking.id,
+          this.tenantId,
+          true
+        );
+        const payload = {
+          ...response.data,
+          isRejected: false,
+          rejectionReason: "",
+        };
+        delete payload._id;
+        delete payload._populated;
+        await ApiBookingService.storeBooking(payload);
+        await this.addToast(
+          ToastService.createToast("booking.unreject.success", "success")
+        );
+        this.finishSave();
+      } catch (error) {
+        await this.addToast(
+          ToastService.createToast("booking.unreject.error", "error")
+        );
+      } finally {
+        this.inProgress = false;
+      }
     },
     finishSave() {
       this.$emit("saved");

--- a/src/components/Booking/BookingEditStatus.vue
+++ b/src/components/Booking/BookingEditStatus.vue
@@ -14,7 +14,9 @@
       >
         <template v-slot:prepend>
           <v-icon :color="booking.isCommitted ? 'primary' : 'grey'">
-            {{ booking.isCommitted ? "mdi-check-circle" : "mdi-circle-outline" }}
+            {{
+              booking.isCommitted ? "mdi-check-circle" : "mdi-circle-outline"
+            }}
           </v-icon>
         </template>
       </v-switch>
@@ -35,7 +37,8 @@
       </v-switch>
 
       <v-switch
-        :input-value="booking.isRejected"
+        :key="rejectedSwitchKey"
+        :input-value="!!booking.isRejected"
         label="Storniert"
         hide-details
         dense
@@ -45,9 +48,7 @@
       >
         <template v-slot:prepend>
           <v-icon :color="booking.isRejected ? 'error' : 'grey'">
-            {{
-              booking.isRejected ? "mdi-cancel" : "mdi-close-circle-outline"
-            }}
+            {{ booking.isRejected ? "mdi-cancel" : "mdi-close-circle-outline" }}
           </v-icon>
         </template>
       </v-switch>
@@ -68,6 +69,11 @@
           rows="2"
           hide-details="auto"
           :rules="rejectionReasonRules"
+        />
+        <CancellationRefundAudit
+          v-if="cancellationRefundAudit"
+          :audit="cancellationRefundAudit"
+          class="mt-3"
         />
       </v-sheet>
     </v-expand-transition>
@@ -108,21 +114,50 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-dialog v-model="unrejectDialog" persistent max-width="520px">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon class="mr-2" color="warning">mdi-undo</v-icon>
+          <span class="text-h6">{{ unrejectDialogTitle }}</span>
+        </v-card-title>
+        <v-card-text>
+          <p class="mb-0 text-body-2">{{ unrejectDialogHint }}</p>
+        </v-card-text>
+        <v-card-actions class="px-4 pb-4">
+          <v-spacer />
+          <v-btn text @click="cancelUnreject">Abbrechen</v-btn>
+          <v-btn color="primary" @click="confirmUnreject">
+            {{ unrejectConfirmLabel }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
 <script>
+import CancellationRefundAudit from "@/components/Booking/CancellationRefundAudit.vue";
+import { getCancellationRefundAudit } from "@/utils/cancellationRefund";
+
 export default {
   name: "BookingEditStatus",
+  components: { CancellationRefundAudit },
   props: {
     booking: {
       type: Object,
       required: true,
     },
+    rejectDialogOpen: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
+      rejectedSwitchKey: 0,
       rejectDialog: false,
+      unrejectDialog: false,
       rejectReasonDraft: "",
     };
   },
@@ -135,6 +170,21 @@ export default {
     },
     rejectDialogTitle() {
       return this.isCancellation ? "Buchung stornieren" : "Buchung ablehnen";
+    },
+    unrejectDialogTitle() {
+      return this.isCancellation
+        ? "Stornierung rückgängig machen"
+        : "Ablehnung rückgängig machen";
+    },
+    unrejectDialogHint() {
+      return this.isCancellation
+        ? "Die Buchung wird wieder als aktiv geführt. Bereits erstellte Stornobelege bleiben in den Anhängen erhalten."
+        : "Die Buchung wird wieder als aktiv geführt.";
+    },
+    unrejectConfirmLabel() {
+      return this.isCancellation
+        ? "Stornierung aufheben"
+        : "Ablehnung aufheben";
     },
     rejectDialogHint() {
       return this.isCancellation
@@ -149,12 +199,41 @@ export default {
     rejectionReasonRules() {
       return [(v) => !!v?.trim() || "Begründung ist erforderlich"];
     },
+    cancellationRefundAudit() {
+      return getCancellationRefundAudit(this.booking);
+    },
+  },
+  watch: {
+    rejectDialogOpen(open, wasOpen) {
+      if (wasOpen && !open) {
+        this.resetRejectedSwitch();
+      }
+    },
+    rejectDialog(open, wasOpen) {
+      if (wasOpen && !open) {
+        this.resetRejectedSwitch();
+      }
+    },
   },
   methods: {
+    resetRejectedSwitch() {
+      this.rejectedSwitchKey += 1;
+    },
     onRejectedChange(value) {
+      if (this.booking.id) {
+        if (value && !this.booking.isRejected) {
+          this.$emit("request-reject");
+        } else if (!value && this.booking.isRejected) {
+          this.unrejectDialog = true;
+        }
+        this.$nextTick(() => this.resetRejectedSwitch());
+        return;
+      }
+
       if (value) {
         this.rejectReasonDraft = this.booking.rejectionReason || "";
         this.rejectDialog = true;
+        this.$nextTick(() => this.resetRejectedSwitch());
         return;
       }
 
@@ -162,13 +241,10 @@ export default {
       this.$set(this.booking, "rejectionReason", null);
     },
     cancelReject() {
-      this.$set(this.booking, "isRejected", true);
-      const draft = (this.rejectReasonDraft || "").trim();
-      if (draft) {
-        this.$set(this.booking, "rejectionReason", draft);
-      }
+      this.$set(this.booking, "isRejected", false);
       this.rejectDialog = false;
       this.rejectReasonDraft = "";
+      this.resetRejectedSwitch();
     },
     confirmReject() {
       const reason = (this.rejectReasonDraft || "").trim();
@@ -178,6 +254,14 @@ export default {
       this.$set(this.booking, "rejectionReason", reason);
       this.rejectDialog = false;
       this.rejectReasonDraft = "";
+    },
+    cancelUnreject() {
+      this.unrejectDialog = false;
+      this.resetRejectedSwitch();
+    },
+    confirmUnreject() {
+      this.unrejectDialog = false;
+      this.$emit("confirm-unreject");
     },
   },
 };

--- a/src/components/Booking/BookingRejectConformationDialog.vue
+++ b/src/components/Booking/BookingRejectConformationDialog.vue
@@ -26,6 +26,15 @@
             label="Kein Stornobeleg erstellen"
           ></v-checkbox>
 
+          <CancellationRefundPreview
+            v-if="!skipCancellation"
+            :preview="refundPreview"
+            :loading="previewLoading"
+            :error="previewError"
+            @update:refund-percentage="refundPercentage = $event"
+            @update:valid="refundValid = $event"
+          />
+
           <div v-if="canProvideBankDetails">
             <v-divider class="mb-4"></v-divider>
             <p class="text-subtitle-2 font-weight-bold mb-1">
@@ -73,8 +82,8 @@
           <v-col class="shrink">
             <v-btn
               color="primary"
-              :loading="loading"
-              :disabled="!valid"
+              :loading="loading || previewLoading"
+              :disabled="!canSubmit"
               type="submit"
               >Ja</v-btn
             >
@@ -89,6 +98,10 @@
 </template>
 
 <script>
+import ApiBookingService from "@/services/api/ApiBookingService";
+import CancellationRefundPreview from "@/components/Booking/CancellationRefundPreview.vue";
+import { getApiErrorMessage } from "@/services/api/apiErrorMessage";
+
 const IBAN_REGEX = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$/;
 const BIC_REGEX = /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
 
@@ -121,7 +134,8 @@ function isValidIban(value) {
 }
 
 export default {
-  name: "BookingDeleteConformationDialog",
+  name: "BookingRejectConformationDialog",
+  components: { CancellationRefundPreview },
   props: {
     open: {
       type: Boolean,
@@ -141,6 +155,11 @@ export default {
       rejectReason: null,
       valid: false,
       skipCancellation: false,
+      refundPreview: null,
+      previewLoading: false,
+      previewError: null,
+      refundPercentage: undefined,
+      refundValid: true,
       bankDetails: {
         bankName: "",
         accountHolder: "",
@@ -162,6 +181,14 @@ export default {
         typeof this.toReject.priceEur === "number" &&
         this.toReject.priceEur > 0 &&
         this.skipCancellation === false
+      );
+    },
+    canSubmit() {
+      return (
+        this.valid &&
+        !this.previewLoading &&
+        (this.skipCancellation ||
+          (!!this.refundPreview && !this.previewError && this.refundValid))
       );
     },
     formattedPrice() {
@@ -192,11 +219,43 @@ export default {
       };
     },
   },
+  watch: {
+    open(value) {
+      if (value) {
+        this.loadRefundPreview();
+      } else {
+        this.resetDialog();
+      }
+    },
+    skipCancellation(value) {
+      if (!value && this.open && !this.refundPreview) {
+        this.loadRefundPreview();
+      }
+      if (value) {
+        this.refundPercentage = undefined;
+      }
+    },
+    "toReject.id"(value, oldValue) {
+      if (this.open && value && value !== oldValue) {
+        this.loadRefundPreview();
+      }
+    },
+  },
   methods: {
     closeDialog() {
-      this.rejectReason = null;
-      this.resetBankDetails();
+      this.resetDialog();
       this.$emit("close");
+    },
+    resetDialog() {
+      this.rejectReason = null;
+      this.skipCancellation = false;
+      this.refundPreview = null;
+      this.previewError = null;
+      this.previewLoading = false;
+      this.refundPercentage = undefined;
+      this.refundValid = true;
+      this.resetBankDetails();
+      this.$nextTick(() => this.$refs.form?.resetValidation());
     },
     resetBankDetails() {
       this.bankDetails = {
@@ -229,14 +288,34 @@ export default {
       if (bic) payload.bic = bic;
       return payload;
     },
+    async loadRefundPreview() {
+      if (!this.toReject?.id || this.skipCancellation) return;
+      this.previewLoading = true;
+      this.previewError = null;
+      this.refundPreview = null;
+      try {
+        this.refundPreview =
+          await ApiBookingService.getCancellationRefundPreview(
+            this.toReject.id
+          );
+      } catch (error) {
+        this.previewError = getApiErrorMessage(
+          error,
+          this.$t("booking.cancellationRefund.previewError")
+        );
+      } finally {
+        this.previewLoading = false;
+      }
+    },
     async onReject() {
-      if (this.valid) {
+      if (this.canSubmit) {
         this.$emit(
           "reject-booking",
           this.toReject.id,
           this.rejectReason,
           this.skipCancellation,
-          this.buildBankDetailsPayload()
+          this.buildBankDetailsPayload(),
+          this.skipCancellation ? undefined : this.refundPercentage
         );
       }
     },

--- a/src/components/Booking/CancellationRefundAmounts.vue
+++ b/src/components/Booking/CancellationRefundAmounts.vue
@@ -1,0 +1,276 @@
+<template>
+  <div class="refund-amounts">
+    <div class="refund-amounts__grid">
+      <div class="refund-amounts__item">
+        <div class="refund-amounts__icon refund-amounts__icon--original">
+          <v-icon x-small>mdi-receipt-text-outline</v-icon>
+        </div>
+        <div class="refund-amounts__content">
+          <span class="refund-amounts__label">
+            {{ $t("booking.cancellationRefund.originalAmount") }}
+          </span>
+          <span class="refund-amounts__value">
+            {{ currency(originalAmountEur) }}
+          </span>
+        </div>
+      </div>
+
+      <div class="refund-amounts__arrow" aria-hidden="true">
+        <v-icon x-small color="grey">mdi-chevron-right</v-icon>
+      </div>
+
+      <div class="refund-amounts__item refund-amounts__item--highlight">
+        <div class="refund-amounts__icon refund-amounts__icon--refund">
+          <v-icon x-small>mdi-cash-refund</v-icon>
+        </div>
+        <div class="refund-amounts__content">
+          <span class="refund-amounts__label">
+            {{ $t("booking.cancellationRefund.refundAmount") }}
+          </span>
+          <span class="refund-amounts__value refund-amounts__value--refund">
+            {{ currency(refundAmountEur) }}
+          </span>
+          <v-chip
+            v-if="refundShareLabel"
+            x-small
+            label
+            color="success"
+            text-color="white"
+            class="refund-amounts__chip mt-1"
+          >
+            {{ refundShareLabel }}
+          </v-chip>
+        </div>
+      </div>
+
+      <div class="refund-amounts__arrow" aria-hidden="true">
+        <v-icon x-small color="grey">mdi-chevron-right</v-icon>
+      </div>
+
+      <div class="refund-amounts__item">
+        <div class="refund-amounts__icon refund-amounts__icon--fee">
+          <v-icon x-small>mdi-hand-coin-outline</v-icon>
+        </div>
+        <div class="refund-amounts__content">
+          <span class="refund-amounts__label">
+            {{ $t("booking.cancellationRefund.cancellationFee") }}
+          </span>
+          <span class="refund-amounts__value">
+            {{ currency(cancellationFeeEur) }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showSplitBar" class="refund-amounts__split">
+      <div
+        class="refund-amounts__split-refund"
+        :style="{ width: `${refundSharePercent}%` }"
+      />
+      <div
+        class="refund-amounts__split-fee"
+        :style="{ width: `${feeSharePercent}%` }"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import FormatService from "@/services/FormatService";
+
+export default {
+  name: "CancellationRefundAmounts",
+  props: {
+    originalAmountEur: {
+      type: Number,
+      default: 0,
+    },
+    refundAmountEur: {
+      type: Number,
+      default: 0,
+    },
+    cancellationFeeEur: {
+      type: Number,
+      default: 0,
+    },
+  },
+  computed: {
+    refundSharePercent() {
+      const original = Number(this.originalAmountEur) || 0;
+      if (original <= 0) return 0;
+      return Math.min(
+        100,
+        Math.max(
+          0,
+          Math.round((Number(this.refundAmountEur) / original) * 100)
+        )
+      );
+    },
+    feeSharePercent() {
+      return Math.max(0, 100 - this.refundSharePercent);
+    },
+    showSplitBar() {
+      return Number(this.originalAmountEur) > 0;
+    },
+    refundShareLabel() {
+      if (!this.showSplitBar) return "";
+      return this.$t("booking.cancellationRefund.refundShare", {
+        percentage: this.refundSharePercent,
+      });
+    },
+  },
+  methods: {
+    currency(value) {
+      return FormatService.currency(Number(value || 0));
+    },
+  },
+};
+</script>
+
+<style scoped>
+.refund-amounts {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  background-color: var(--v-accent-base, #fafafa);
+  overflow: hidden;
+}
+
+.theme--dark .refund-amounts {
+  border-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.refund-amounts__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 0;
+  padding: 10px 8px;
+}
+
+.refund-amounts__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  padding: 2px 6px;
+}
+
+.refund-amounts__item--highlight {
+  background: rgba(76, 175, 80, 0.08);
+  border-radius: 4px;
+}
+
+.theme--dark .refund-amounts__item--highlight {
+  background: rgba(76, 175, 80, 0.14);
+}
+
+.refund-amounts__arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.45;
+  padding-top: 10px;
+}
+
+.refund-amounts__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.refund-amounts__icon--original {
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.refund-amounts__icon--refund {
+  background: rgba(76, 175, 80, 0.18);
+  color: var(--v-success-base, #4caf50);
+}
+
+.refund-amounts__icon--fee {
+  background: rgba(251, 140, 0, 0.16);
+  color: var(--v-warning-darken1, #f57c00);
+}
+
+.theme--dark .refund-amounts__icon--original {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.refund-amounts__content {
+  min-width: 0;
+}
+
+.refund-amounts__label {
+  display: block;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.55);
+  margin-bottom: 2px;
+}
+
+.theme--dark .refund-amounts__label {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.refund-amounts__value {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.25;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.refund-amounts__value--refund {
+  color: var(--v-success-base, #4caf50);
+}
+
+.refund-amounts__chip {
+  height: 18px !important;
+  font-size: 0.65rem !important;
+}
+
+.refund-amounts__split {
+  display: flex;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.theme--dark .refund-amounts__split {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.refund-amounts__split-refund {
+  background: var(--v-success-base, #4caf50);
+  transition: width 0.25s ease;
+}
+
+.refund-amounts__split-fee {
+  background: rgba(251, 140, 0, 0.75);
+  transition: width 0.25s ease;
+}
+
+@media (max-width: 700px) {
+  .refund-amounts__grid {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .refund-amounts__arrow {
+    display: none;
+  }
+
+  .refund-amounts__item--highlight {
+    order: -1;
+  }
+}
+</style>

--- a/src/components/Booking/CancellationRefundAudit.vue
+++ b/src/components/Booking/CancellationRefundAudit.vue
@@ -1,0 +1,61 @@
+<template>
+  <CancellationRefundPanel
+    v-if="audit"
+    :title="$t('booking.cancellationRefund.auditTitle')"
+    icon="mdi-history"
+    :original-amount-eur="Number(audit.originalAmountEur || 0)"
+    :refund-amount-eur="Number(audit.refundAmountEur || 0)"
+    :cancellation-fee-eur="Number(audit.cancellationFeeEur || 0)"
+    :policy-summary="policySummary"
+    :footer="cancelledAtFooter"
+  />
+</template>
+
+<script>
+import CancellationRefundPanel from "@/components/Booking/CancellationRefundPanel.vue";
+
+export default {
+  name: "CancellationRefundAudit",
+  components: { CancellationRefundPanel },
+  props: {
+    audit: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    policySummary() {
+      if (!this.audit) return "";
+
+      const days = this.formatDays(this.audit.daysBeforeStart);
+      const percentage = this.audit.appliedRefundPercentage;
+
+      if (this.audit.adminOverride) {
+        return this.$t("booking.cancellationRefund.auditOverride", {
+          days,
+          suggested: this.audit.suggestedRefundPercentage,
+          applied: percentage,
+        });
+      }
+
+      return this.$t("booking.cancellationRefund.singlePolicy", {
+        days,
+        percentage,
+      });
+    },
+    cancelledAtFooter() {
+      if (!this.audit?.cancelledAt) return "";
+      const label = new Intl.DateTimeFormat("de-DE", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(Number(this.audit.cancelledAt)));
+      return `${this.$t("booking.cancellationRefund.cancelledAt")}: ${label}`;
+    },
+  },
+  methods: {
+    formatDays(value) {
+      return value === null || value === undefined ? "–" : value;
+    },
+  },
+};
+</script>

--- a/src/components/Booking/CancellationRefundPanel.vue
+++ b/src/components/Booking/CancellationRefundPanel.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="cancellation-refund-panel">
+    <v-divider v-if="showDivider" class="my-4" />
+
+    <div class="cancellation-refund-panel__header">
+      <div class="cancellation-refund-panel__title">
+        <v-icon color="primary" small class="mr-2">{{ icon }}</v-icon>
+        <span class="text-subtitle-2 font-weight-bold">{{ title }}</span>
+      </div>
+      <slot name="header-action" />
+    </div>
+
+    <CancellationRefundAmounts
+      class="mt-2"
+      :original-amount-eur="originalAmountEur"
+      :refund-amount-eur="refundAmountEur"
+      :cancellation-fee-eur="cancellationFeeEur"
+    />
+
+    <slot />
+
+    <v-alert
+      v-if="policySummary"
+      type="info"
+      text
+      dense
+      class="cancellation-refund-panel__policy mt-2 mb-0"
+    >
+      {{ policySummary }}
+    </v-alert>
+
+    <div
+      v-if="footer"
+      class="cancellation-refund-panel__footer text-caption text--secondary mt-1"
+    >
+      {{ footer }}
+    </div>
+  </div>
+</template>
+
+<script>
+import CancellationRefundAmounts from "@/components/Booking/CancellationRefundAmounts.vue";
+
+export default {
+  name: "CancellationRefundPanel",
+  components: { CancellationRefundAmounts },
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: String,
+      default: "mdi-cash-refund",
+    },
+    originalAmountEur: {
+      type: Number,
+      default: 0,
+    },
+    refundAmountEur: {
+      type: Number,
+      default: 0,
+    },
+    cancellationFeeEur: {
+      type: Number,
+      default: 0,
+    },
+    policySummary: {
+      type: String,
+      default: "",
+    },
+    footer: {
+      type: String,
+      default: "",
+    },
+    showDivider: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.cancellation-refund-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.cancellation-refund-panel__title {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.cancellation-refund-panel__policy {
+  border-radius: 4px !important;
+}
+</style>

--- a/src/components/Booking/CancellationRefundPreview.vue
+++ b/src/components/Booking/CancellationRefundPreview.vue
@@ -1,0 +1,264 @@
+<template>
+  <div>
+    <v-skeleton-loader
+      v-if="loading"
+      type="list-item-three-line"
+      class="mb-2"
+    />
+    <v-alert v-else-if="error" type="error" text>
+      {{ error }}
+    </v-alert>
+    <CancellationRefundPanel
+      v-else-if="preview"
+      show-divider
+      :title="$t('booking.cancellationRefund.title')"
+      :original-amount-eur="originalAmountEur"
+      :refund-amount-eur="refundAmountEur"
+      :cancellation-fee-eur="cancellationFeeEur"
+      :policy-summary="policySummary"
+    >
+      <v-simple-table v-if="isGroup" dense class="mt-3 mb-1 refund-group-table">
+        <thead>
+          <tr>
+            <th>{{ $t("booking.cancellationRefund.booking") }}</th>
+            <th class="text-right">
+              {{ $t("booking.cancellationRefund.days") }}
+            </th>
+            <th class="text-right">
+              {{ $t("booking.cancellationRefund.policyPercentage") }}
+            </th>
+            <th class="text-right">
+              {{ $t("booking.cancellationRefund.originalAmount") }}
+            </th>
+            <th class="text-right">
+              {{ $t("booking.cancellationRefund.refundAmount") }}
+            </th>
+            <th class="text-right">
+              {{ $t("booking.cancellationRefund.cancellationFee") }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="booking in displayedBookings" :key="booking.bookingId">
+            <td>{{ booking.bookingId }}</td>
+            <td class="text-right">
+              {{ formatDays(booking.daysBeforeStart) }}
+            </td>
+            <td class="text-right">
+              {{ booking.suggestedRefundPercentage }} %
+            </td>
+            <td class="text-right">
+              {{ currency(booking.originalAmountEur) }}
+            </td>
+            <td class="text-right">{{ currency(booking.refundAmountEur) }}</td>
+            <td class="text-right">
+              {{ currency(booking.cancellationFeeEur) }}
+            </td>
+          </tr>
+        </tbody>
+      </v-simple-table>
+
+      <v-checkbox
+        v-model="useOverride"
+        :label="$t('booking.cancellationRefund.override')"
+        hide-details
+        class="mt-3 mb-0"
+        @change="emitOverride"
+      />
+      <v-text-field
+        v-if="useOverride"
+        v-model.number="localPercentage"
+        :label="$t('booking.cancellationRefund.overridePercentage')"
+        :rules="percentageRules"
+        type="number"
+        min="0"
+        max="100"
+        step="1"
+        suffix="%"
+        outlined
+        dense
+        class="mt-3 mb-0"
+        @input="emitOverride"
+      />
+    </CancellationRefundPanel>
+  </div>
+</template>
+
+<script>
+import CancellationRefundPanel from "@/components/Booking/CancellationRefundPanel.vue";
+import FormatService from "@/services/FormatService";
+
+export default {
+  name: "CancellationRefundPreview",
+  components: { CancellationRefundPanel },
+  props: {
+    preview: {
+      type: Object,
+      default: null,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    error: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      useOverride: false,
+      localPercentage: 100,
+    };
+  },
+  computed: {
+    isGroup() {
+      return Array.isArray(this.preview?.bookings);
+    },
+    percentageRules() {
+      return [
+        (value) =>
+          (value !== "" && value !== null && value !== undefined) ||
+          this.$t("validation.required"),
+        (value) =>
+          Number.isInteger(Number(value)) ||
+          this.$t("validation.integerRequired"),
+        (value) =>
+          (Number(value) >= 0 && Number(value) <= 100) ||
+          this.$t("booking.cancellationRefund.percentageRange"),
+      ];
+    },
+    isOverrideValid() {
+      return (
+        !this.useOverride ||
+        (Number.isInteger(Number(this.localPercentage)) &&
+          Number(this.localPercentage) >= 0 &&
+          Number(this.localPercentage) <= 100)
+      );
+    },
+    displayedBookings() {
+      if (!this.isGroup) return [];
+      return this.preview.bookings.map((booking) => {
+        if (!this.useOverride || !this.isOverrideValid) return booking;
+        const refundAmountEur = this.calculateRefund(
+          booking.originalAmountEur,
+          this.localPercentage
+        );
+        return {
+          ...booking,
+          refundAmountEur,
+          cancellationFeeEur:
+            Math.round(
+              (Number(booking.originalAmountEur) - refundAmountEur) * 100
+            ) / 100,
+        };
+      });
+    },
+    originalAmountEur() {
+      return this.isGroup
+        ? this.sumBookings("originalAmountEur")
+        : Number(this.preview?.originalAmountEur || 0);
+    },
+    refundAmountEur() {
+      if (this.isGroup) return this.sumBookings("refundAmountEur");
+      if (!this.useOverride || !this.isOverrideValid) {
+        return Number(this.preview?.refundAmountEur || 0);
+      }
+      return this.calculateRefund(this.originalAmountEur, this.localPercentage);
+    },
+    cancellationFeeEur() {
+      return (
+        Math.round((this.originalAmountEur - this.refundAmountEur) * 100) / 100
+      );
+    },
+    policySummary() {
+      if (this.isGroup) {
+        const percentages = [
+          ...new Set(
+            this.preview.bookings.map(
+              (booking) => booking.suggestedRefundPercentage
+            )
+          ),
+        ];
+        if (percentages.length === 1) {
+          return this.$t("booking.cancellationRefund.groupPolicySingle", {
+            percentage: percentages[0],
+          });
+        }
+        return this.$t("booking.cancellationRefund.groupPolicyMixed");
+      }
+      return this.$t("booking.cancellationRefund.singlePolicy", {
+        days: this.formatDays(this.preview.daysBeforeStart),
+        percentage: this.preview.suggestedRefundPercentage,
+      });
+    },
+  },
+  watch: {
+    preview: {
+      immediate: true,
+      handler(preview) {
+        this.useOverride = false;
+        this.localPercentage = this.defaultPercentage(preview);
+        this.emitOverride();
+      },
+    },
+    isOverrideValid: {
+      immediate: true,
+      handler(value) {
+        this.$emit("update:valid", value);
+      },
+    },
+  },
+  methods: {
+    defaultPercentage(preview) {
+      if (!preview) return 100;
+      if (Array.isArray(preview.bookings)) {
+        const percentages = [
+          ...new Set(
+            preview.bookings.map((booking) => booking.suggestedRefundPercentage)
+          ),
+        ];
+        return percentages.length === 1 ? percentages[0] : 100;
+      }
+      return preview.suggestedRefundPercentage ?? 100;
+    },
+    emitOverride() {
+      this.$emit(
+        "update:refund-percentage",
+        this.useOverride && this.isOverrideValid
+          ? Number(this.localPercentage)
+          : undefined
+      );
+      this.$emit("update:valid", this.isOverrideValid);
+    },
+    sumBookings(field) {
+      return (
+        this.displayedBookings.reduce(
+          (sum, booking) => sum + Math.round(Number(booking[field] || 0) * 100),
+          0
+        ) / 100
+      );
+    },
+    calculateRefund(originalAmountEur, percentage) {
+      const originalAmountCents = Math.round(
+        Number(originalAmountEur || 0) * 100
+      );
+      return Math.round((originalAmountCents * Number(percentage)) / 100) / 100;
+    },
+    currency(value) {
+      return FormatService.currency(Number(value || 0));
+    },
+    formatDays(value) {
+      return value === null || value === undefined ? "–" : value;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.refund-group-table {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  overflow: hidden;
+}
+</style>

--- a/src/components/Booking/GroupBookingDeleteConformationDialog.vue
+++ b/src/components/Booking/GroupBookingDeleteConformationDialog.vue
@@ -14,22 +14,42 @@
       </v-card-text>
       <v-card-text class="d-flex justify-center">
         <v-col cols="auto">
-          <v-btn
-            large
-            color="primary"
-            :loading="inProgress"
-            @click="onDeleteGroup"
-            >Serie löschen</v-btn
-          >
+          <v-tooltip :disabled="!groupDeleteDisabled" top>
+            <template v-slot:activator="{ on }">
+              <div v-on="on">
+                <v-btn
+                  large
+                  color="primary"
+                  :loading="inProgress"
+                  :disabled="groupDeleteDisabled"
+                  @click="onDeleteGroup"
+                  >Serie löschen</v-btn
+                >
+              </div>
+            </template>
+            <span>
+              Bestätigte oder bezahlte Buchungen müssen storniert werden.
+            </span>
+          </v-tooltip>
         </v-col>
         <v-col cols="auto">
-          <v-btn
-            large
-            color="primary"
-            @click="onDeleteSingle"
-            :loading="inProgress"
-            >Nur diese Buchung löschen</v-btn
-          >
+          <v-tooltip :disabled="!singleDeleteDisabled" top>
+            <template v-slot:activator="{ on }">
+              <div v-on="on">
+                <v-btn
+                  large
+                  color="primary"
+                  :disabled="singleDeleteDisabled"
+                  @click="onDeleteSingle"
+                  :loading="inProgress"
+                  >Nur diese Buchung löschen</v-btn
+                >
+              </div>
+            </template>
+            <span>
+              Bestätigte oder bezahlte Buchungen müssen storniert werden.
+            </span>
+          </v-tooltip>
         </v-col>
       </v-card-text>
       <v-card-actions>
@@ -55,6 +75,14 @@ export default {
       required: true,
     },
     inProgress: {
+      type: Boolean,
+      default: false,
+    },
+    singleDeleteDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    groupDeleteDisabled: {
       type: Boolean,
       default: false,
     },

--- a/src/components/Booking/GroupBookingRejectConformationDialog.vue
+++ b/src/components/Booking/GroupBookingRejectConformationDialog.vue
@@ -1,68 +1,86 @@
 <template>
   <v-dialog v-model="openDialog" persistent max-width="800px">
     <v-card color="accent">
-      <v-card-title>
-        <v-icon class="mr-2" color="error">mdi-alert</v-icon>
-        <span class="text-h5">Buchung stornieren</span>
-      </v-card-title>
-      <v-card-text>
-        <span class="text-h6">
-          Die Buchung
-          <strong>{{ toReject.id }}</strong> ist Teil einer Serienbuchung.
-          Möchten Sie die gesamte Serie stornieren?
-        </span>
-      </v-card-text>
-      <v-card-text v-if="error" class="text-center">
-        <v-alert type="error" border="left" elevation="2">
-          {{ error }}
-        </v-alert>
-      </v-card-text>
-      <v-card-text>
-        <v-textarea
-          outlined
-          v-model="rejectReason"
-          label="Begründung der Stornierung"
-          placeholder="Aus welchem Grund wird die Stornierung durchgeführt?"
-          rows="2"
-        ></v-textarea>
-        <v-checkbox
-          v-model="skipCancellation"
-          label="Kein Stornobeleg erstellen"
-        ></v-checkbox>
-      </v-card-text>
-      <v-card-text class="d-flex justify-center">
-        <v-col cols="auto">
+      <v-form ref="form" v-model="valid" @submit.prevent="onReject">
+        <v-card-title>
+          <v-icon class="mr-2" color="error">mdi-alert</v-icon>
+          <span class="text-h5">Buchung stornieren</span>
+        </v-card-title>
+        <v-card-text>
+          <span class="text-h6">
+            Die Buchung
+            <strong>{{ toReject.id }}</strong> ist Teil einer Serienbuchung.
+          </span>
+          <v-radio-group v-model="cancellationScope" class="mt-4">
+            <v-radio
+              value="group"
+              :label="$t('booking.cancellationRefund.cancelGroup')"
+            />
+            <v-radio
+              value="single"
+              :label="$t('booking.cancellationRefund.cancelSingle')"
+            />
+          </v-radio-group>
+        </v-card-text>
+        <v-card-text v-if="error" class="text-center">
+          <v-alert type="error" border="left" elevation="2">
+            {{ error }}
+          </v-alert>
+        </v-card-text>
+        <v-card-text>
+          <v-textarea
+            outlined
+            v-model="rejectReason"
+            label="Begründung der Stornierung"
+            placeholder="Aus welchem Grund wird die Stornierung durchgeführt?"
+            :rules="[
+              (value) => !!value?.trim() || 'Begründung ist erforderlich',
+            ]"
+            rows="2"
+          ></v-textarea>
+          <v-checkbox
+            v-model="skipCancellation"
+            label="Kein Stornobeleg erstellen"
+          ></v-checkbox>
+          <CancellationRefundPreview
+            v-if="!skipCancellation"
+            :preview="refundPreview"
+            :loading="previewLoading"
+            :error="previewError"
+            @update:refund-percentage="refundPercentage = $event"
+            @update:valid="refundValid = $event"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
           <v-btn
-            large
             color="primary"
-            :loading="inProgress"
-            @click="onRejectGroup"
-            >Serie stornieren</v-btn
+            :loading="inProgress || previewLoading"
+            :disabled="!canSubmit"
+            type="submit"
           >
-        </v-col>
-        <v-col cols="auto">
-          <v-btn
-            large
-            color="primary"
-            @click="onRejectSingle"
-            :loading="inProgress"
-            >Nur diese Buchung stornieren</v-btn
-          >
-        </v-col>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-col class="shrink">
+            {{
+              cancellationScope === "group"
+                ? $t("booking.cancellationRefund.cancelGroup")
+                : $t("booking.cancellationRefund.cancelSingle")
+            }}
+          </v-btn>
           <v-btn outlined @click="closeDialog">Abbrechen</v-btn>
-        </v-col>
-      </v-card-actions>
+        </v-card-actions>
+      </v-form>
     </v-card>
   </v-dialog>
 </template>
 
 <script>
+import ApiBookingService from "@/services/api/ApiBookingService";
+import ApiGroupBookingService from "@/services/api/ApiGroupBookingService";
+import CancellationRefundPreview from "@/components/Booking/CancellationRefundPreview.vue";
+import { getApiErrorMessage } from "@/services/api/apiErrorMessage";
+
 export default {
   name: "GroupBookingRejectConformationDialog",
+  components: { CancellationRefundPreview },
   props: {
     open: {
       type: Boolean,
@@ -71,6 +89,10 @@ export default {
     toReject: {
       type: Object,
       required: true,
+    },
+    groupBookingId: {
+      type: String,
+      default: null,
     },
     inProgress: {
       type: Boolean,
@@ -86,6 +108,13 @@ export default {
     return {
       rejectReason: null,
       skipCancellation: false,
+      cancellationScope: "group",
+      valid: false,
+      refundPreview: null,
+      previewLoading: false,
+      previewError: null,
+      refundPercentage: undefined,
+      refundValid: true,
     };
   },
   computed: {
@@ -94,25 +123,113 @@ export default {
         return this.open;
       },
     },
+    canSubmit() {
+      return (
+        this.valid &&
+        !this.previewLoading &&
+        (this.skipCancellation ||
+          (!!this.refundPreview && !this.previewError && this.refundValid))
+      );
+    },
+  },
+  watch: {
+    open(value) {
+      if (value) {
+        this.loadRefundPreview();
+      } else {
+        this.resetDialog();
+      }
+    },
+    cancellationScope() {
+      if (this.open && !this.skipCancellation) {
+        this.loadRefundPreview();
+      }
+    },
+    skipCancellation(value) {
+      if (!value && this.open) {
+        this.loadRefundPreview();
+      }
+      if (value) {
+        this.refundPercentage = undefined;
+      }
+    },
+    groupBookingId(value, oldValue) {
+      if (this.open && value && value !== oldValue) {
+        this.loadRefundPreview();
+      }
+    },
+    "toReject.id"(value, oldValue) {
+      if (this.open && value && value !== oldValue) {
+        this.loadRefundPreview();
+      }
+    },
   },
   methods: {
     closeDialog() {
+      this.resetDialog();
       this.$emit("close");
     },
-    async onRejectSingle() {
+    resetDialog() {
+      this.rejectReason = null;
+      this.skipCancellation = false;
+      this.cancellationScope = "group";
+      this.refundPreview = null;
+      this.previewLoading = false;
+      this.previewError = null;
+      this.refundPercentage = undefined;
+      this.refundValid = true;
+      this.$nextTick(() => this.$refs.form?.resetValidation());
+    },
+    async loadRefundPreview() {
+      if (this.skipCancellation || !this.toReject?.id) return;
+      if (this.cancellationScope === "group" && !this.groupBookingId) return;
+      this.previewLoading = true;
+      this.previewError = null;
+      this.refundPreview = null;
+      try {
+        if (this.cancellationScope === "group") {
+          this.refundPreview =
+            await ApiGroupBookingService.getCancellationRefundPreview(
+              null,
+              this.groupBookingId
+            );
+        } else {
+          this.refundPreview =
+            await ApiBookingService.getCancellationRefundPreview(
+              this.toReject.id
+            );
+        }
+      } catch (error) {
+        this.previewError = getApiErrorMessage(
+          error,
+          this.$t("booking.cancellationRefund.previewError")
+        );
+      } finally {
+        this.previewLoading = false;
+      }
+    },
+    async onReject() {
+      if (!this.canSubmit) return;
+      const refundPercentage = this.skipCancellation
+        ? undefined
+        : this.refundPercentage;
+      if (this.cancellationScope === "group") {
+        this.$emit(
+          "reject-group-booking",
+          this.toReject.id,
+          this.rejectReason,
+          this.skipCancellation,
+          refundPercentage
+        );
+        return;
+      }
       this.$emit(
         "reject-single-booking",
         this.toReject.id,
         this.rejectReason,
-        this.skipCancellation
-      );
-    },
-    async onRejectGroup() {
-      this.$emit(
-        "reject-group-booking",
-        this.toReject.id,
-        this.rejectReason,
-        this.skipCancellation
+        this.skipCancellation,
+        undefined,
+        refundPercentage
       );
     },
   },

--- a/src/components/Booking/GroupBookingRejectConformationDialog.vue
+++ b/src/components/Booking/GroupBookingRejectConformationDialog.vue
@@ -50,6 +50,58 @@
             @update:refund-percentage="refundPercentage = $event"
             @update:valid="refundValid = $event"
           />
+
+          <div v-if="canProvideBankDetails">
+            <v-divider class="mb-4"></v-divider>
+            <p class="text-subtitle-2 font-weight-bold mb-1">
+              {{ $t("booking.cancellationRefund.bankDetailsTitle") }}
+            </p>
+            <p class="text-caption mb-3">
+              {{
+                cancellationScope === "group"
+                  ? $t("booking.cancellationRefund.bankDetailsHintGroup", {
+                      amount: formattedPrice
+                        ? ` (Betrag: ${formattedPrice})`
+                        : "",
+                    })
+                  : $t("booking.cancellationRefund.bankDetailsHintSingle", {
+                      amount: formattedPrice
+                        ? ` (Betrag: ${formattedPrice})`
+                        : "",
+                    })
+              }}
+            </p>
+
+            <v-text-field
+              outlined
+              dense
+              v-model="bankDetails.accountHolder"
+              :label="$t('booking.cancellationRefund.accountHolder')"
+              :rules="bankRules.accountHolder"
+            ></v-text-field>
+            <v-text-field
+              outlined
+              dense
+              v-model="bankDetails.iban"
+              :label="$t('booking.cancellationRefund.iban')"
+              :hint="$t('booking.cancellationRefund.ibanHint')"
+              :rules="bankRules.iban"
+              @input="onIbanInput"
+            ></v-text-field>
+            <v-text-field
+              outlined
+              dense
+              v-model="bankDetails.bic"
+              :label="$t('booking.cancellationRefund.bic')"
+              :rules="bankRules.bic"
+            ></v-text-field>
+            <v-text-field
+              outlined
+              dense
+              v-model="bankDetails.bankName"
+              :label="$t('booking.cancellationRefund.bankName')"
+            ></v-text-field>
+          </div>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -77,6 +129,37 @@ import ApiBookingService from "@/services/api/ApiBookingService";
 import ApiGroupBookingService from "@/services/api/ApiGroupBookingService";
 import CancellationRefundPreview from "@/components/Booking/CancellationRefundPreview.vue";
 import { getApiErrorMessage } from "@/services/api/apiErrorMessage";
+
+const IBAN_REGEX = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$/;
+const BIC_REGEX = /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
+
+function normalizeIban(value) {
+  return (value || "").replace(/\s+/g, "").toUpperCase();
+}
+
+function normalizeBic(value) {
+  return (value || "").replace(/\s+/g, "").toUpperCase();
+}
+
+function isValidIban(value) {
+  const iban = normalizeIban(value);
+  if (!IBAN_REGEX.test(iban)) return false;
+  const rearranged = iban.slice(4) + iban.slice(0, 4);
+  const numeric = rearranged
+    .split("")
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      if (code >= 65 && code <= 90) return (code - 55).toString();
+      return ch;
+    })
+    .join("");
+  let remainder = 0;
+  for (let i = 0; i < numeric.length; i += 7) {
+    const block = remainder.toString() + numeric.substr(i, 7);
+    remainder = parseInt(block, 10) % 97;
+  }
+  return remainder === 1;
+}
 
 export default {
   name: "GroupBookingRejectConformationDialog",
@@ -115,6 +198,12 @@ export default {
       previewError: null,
       refundPercentage: undefined,
       refundValid: true,
+      bankDetails: {
+        bankName: "",
+        accountHolder: "",
+        iban: "",
+        bic: "",
+      },
     };
   },
   computed: {
@@ -123,6 +212,15 @@ export default {
         return this.open;
       },
     },
+    canProvideBankDetails() {
+      return !!(
+        this.toReject &&
+        this.toReject.isPayed === true &&
+        typeof this.toReject.priceEur === "number" &&
+        this.toReject.priceEur > 0 &&
+        this.skipCancellation === false
+      );
+    },
     canSubmit() {
       return (
         this.valid &&
@@ -130,6 +228,37 @@ export default {
         (this.skipCancellation ||
           (!!this.refundPreview && !this.previewError && this.refundValid))
       );
+    },
+    formattedPrice() {
+      const amount =
+        this.cancellationScope === "group" &&
+        typeof this.refundPreview?.originalAmountEur === "number"
+          ? this.refundPreview.originalAmountEur
+          : this.toReject?.priceEur;
+      if (typeof amount !== "number") return "";
+      try {
+        return new Intl.NumberFormat("de-DE", {
+          style: "currency",
+          currency: "EUR",
+        }).format(amount);
+      } catch (e) {
+        return `${amount.toFixed(2)} €`;
+      }
+    },
+    bankRules() {
+      return {
+        accountHolder: [],
+        iban: [
+          (v) =>
+            !v || isValidIban(v) || "Bitte geben Sie eine gültige IBAN an.",
+        ],
+        bic: [
+          (v) =>
+            !v ||
+            BIC_REGEX.test(normalizeBic(v)) ||
+            "Bitte geben Sie eine gültige BIC an.",
+        ],
+      };
     },
   },
   watch: {
@@ -178,7 +307,39 @@ export default {
       this.previewError = null;
       this.refundPercentage = undefined;
       this.refundValid = true;
+      this.resetBankDetails();
       this.$nextTick(() => this.$refs.form?.resetValidation());
+    },
+    resetBankDetails() {
+      this.bankDetails = {
+        bankName: "",
+        accountHolder: "",
+        iban: "",
+        bic: "",
+      };
+    },
+    onIbanInput(value) {
+      const normalized = normalizeIban(value);
+      const formatted = normalized.replace(/(.{4})/g, "$1 ").trim();
+      if (formatted !== value) {
+        this.bankDetails.iban = formatted;
+      }
+    },
+    buildBankDetailsPayload() {
+      if (!this.canProvideBankDetails) return undefined;
+      const accountHolder = (this.bankDetails.accountHolder || "").trim();
+      const iban = normalizeIban(this.bankDetails.iban);
+      const bic = normalizeBic(this.bankDetails.bic);
+      const bank = (this.bankDetails.bankName || "").trim();
+
+      if (!accountHolder && !iban && !bic && !bank) return undefined;
+
+      const payload = {};
+      if (bank) payload.bankName = bank;
+      if (accountHolder) payload.accountHolder = accountHolder;
+      if (iban) payload.iban = iban;
+      if (bic) payload.bic = bic;
+      return payload;
     },
     async loadRefundPreview() {
       if (this.skipCancellation || !this.toReject?.id) return;
@@ -213,12 +374,14 @@ export default {
       const refundPercentage = this.skipCancellation
         ? undefined
         : this.refundPercentage;
+      const bankDetails = this.buildBankDetailsPayload();
       if (this.cancellationScope === "group") {
         this.$emit(
           "reject-group-booking",
           this.toReject.id,
           this.rejectReason,
           this.skipCancellation,
+          bankDetails,
           refundPercentage
         );
         return;
@@ -228,7 +391,7 @@ export default {
         this.toReject.id,
         this.rejectReason,
         this.skipCancellation,
-        undefined,
+        bankDetails,
         refundPercentage
       );
     },

--- a/src/components/Mail/SnippetEditorDialog.vue
+++ b/src/components/Mail/SnippetEditorDialog.vue
@@ -240,6 +240,7 @@ import {
 } from "./snippetCatalog.js";
 import {
   SNIPPET_VARIABLES,
+  BOOKING_CANCEL_SNIPPET_VARIABLES,
   SAMPLE_DATA,
 } from "./templateVariables.js";
 import { buildSnippetPreviewExtrasHtml } from "./snippetPreviewExtras.js";
@@ -284,6 +285,9 @@ export default {
       return getSnippetCatalogEntry(this.snippetKey);
     },
     variables() {
+      if (this.snippetKey === "booking-cancel") {
+        return [...SNIPPET_VARIABLES, ...BOOKING_CANCEL_SNIPPET_VARIABLES];
+      }
       return SNIPPET_VARIABLES;
     },
     sampleData() {
@@ -470,7 +474,18 @@ export default {
       if (this.handlebarsLib) return this.handlebarsLib;
       try {
         const mod = await import(/* webpackChunkName: "handlebars" */ "handlebars");
-        this.handlebarsLib = mod.default || mod;
+        const hb = mod.default || mod;
+        if (!hb.helpers.priceFormatted) {
+          const currencyFormatter = new Intl.NumberFormat("de-DE", {
+            style: "currency",
+            currency: "EUR",
+          });
+          hb.registerHelper("priceFormatted", (value) => {
+            if (typeof value !== "number") return "–";
+            return currencyFormatter.format(value);
+          });
+        }
+        this.handlebarsLib = hb;
       } catch (e) {
         this.handlebarsLib = null;
       }

--- a/src/components/Mail/snippetCatalog.js
+++ b/src/components/Mail/snippetCatalog.js
@@ -150,9 +150,37 @@ export const SNIPPET_CATALOG = [
     title: "Stornierungsmitteilung",
     description: "Stornierungsmitteilung an den Buchenden.",
     icon: "mdi-cancel",
-    defaultTemplate: "<p>Die nachfolgende Buchung wurde storniert:</p>",
+    defaultTemplate: `<p>Die nachfolgende Buchung wurde storniert:</p>
+
+{{#if hasRefundPreview}}
+  <p>
+    <strong>Erstattung</strong>:
+    {{priceFormatted refundAmountEur}}
+    ({{refundPercentage}}&nbsp;%)
+    {{#if hasCancellationFee}}
+      <br />
+      Einbehalt (Stornogebühr): {{priceFormatted cancellationFeeEur}}
+    {{/if}}
+  </p>
+{{/if}}
+`,
     defaultBlocks: [
-      row([txt("<p>Die nachfolgende Buchung wurde storniert:</p>")]),
+      row([
+        txt(`<p>Die nachfolgende Buchung wurde storniert:</p>
+
+{{#if hasRefundPreview}}
+  <p>
+    <strong>Erstattung</strong>:
+    {{priceFormatted refundAmountEur}}
+    ({{refundPercentage}}&nbsp;%)
+    {{#if hasCancellationFee}}
+      <br />
+      Einbehalt (Stornogebühr): {{priceFormatted cancellationFeeEur}}
+    {{/if}}
+  </p>
+{{/if}}
+`),
+      ]),
     ],
   },
   {

--- a/src/components/Mail/templateVariables.js
+++ b/src/components/Mail/templateVariables.js
@@ -340,6 +340,13 @@ export const INVOICE_VARIABLES = [
 
 export const CANCELLATION_VARIABLES = [
   {
+    name: "title",
+    placeholder: "{{title}}",
+    label: "Dokumenttitel",
+    description:
+      "Titel des Belegs (z. B. „Stornorechnung“ oder „Sammel-Stornorechnung“)",
+  },
+  {
     name: "cancellationNumber",
     placeholder: "{{cancellationNumber}}",
     label: "Stornobelegnummer",
@@ -367,7 +374,7 @@ export const CANCELLATION_VARIABLES = [
     name: "cancellationDate",
     placeholder: "{{cancellationDate}}",
     label: "Stornodatum",
-    description: "Datum der Stornierung",
+    description: "Datum und Uhrzeit der Stornierung",
   },
   {
     name: "invoiceAddress",
@@ -379,13 +386,85 @@ export const CANCELLATION_VARIABLES = [
     name: "refundAmount",
     placeholder: "{{refundAmount}}",
     label: "Erstattungsbetrag",
-    description: "Erstattungsbetrag",
+    description: "Erstattungsbetrag (formatiert)",
+  },
+  {
+    name: "cancellationFee",
+    placeholder: "{{cancellationFee}}",
+    label: "Einbehaltener Betrag",
+    description: "Einbehaltener Betrag / Stornogebühr (formatiert)",
   },
   {
     name: "cancellationReason",
     placeholder: "{{cancellationReason}}",
     label: "Stornogrund",
     description: "Grund der Stornierung",
+  },
+  {
+    name: "daysBeforeStartLabel",
+    placeholder: "{{daysBeforeStartLabel}}",
+    label: "Tage vor Buchungsbeginn",
+    description:
+      "Kalendertage vor Buchungsbeginn als Text (oder „nicht verfügbar“)",
+  },
+  {
+    name: "refundPercentage",
+    placeholder: "{{refundPercentage}}",
+    label: "Erstattungsprozentsatz",
+    description: "Tatsächlich angewandter Erstattungsprozentsatz (0–100)",
+  },
+  {
+    name: "suggestedRefundPercentage",
+    placeholder: "{{suggestedRefundPercentage}}",
+    label: "Vorgeschlagener Prozentsatz",
+    description:
+      "Aus der Mandantenstaffel vorgeschlagener Erstattungsprozentsatz",
+  },
+  {
+    name: "calculationMode",
+    placeholder: "{{calculationMode}}",
+    label: "Berechnungsart",
+    description:
+      "Art der Erstattungsberechnung (z. B. Mandantenregel, manuell, System)",
+  },
+  {
+    name: "appliedTierDays",
+    placeholder: "{{appliedTierDays}}",
+    label: "Angewandte Staffelstufe",
+    description:
+      "Schwellenwert (Tage) der angewandten Erstattungsstufe, oder leer",
+  },
+  {
+    name: "isFullRefund",
+    placeholder:
+      "{{#if isFullRefund}}in voller Höhe{{else}}anteilig gemäß der nachfolgenden Berechnung{{/if}}",
+    label: "Volle Erstattung (Bedingung)",
+    description:
+      "Wahr, wenn 100 % erstattet werden – Formulierung in den Zweigen anpassen",
+  },
+  {
+    name: "hasCancellationFee",
+    placeholder:
+      "{{#if hasCancellationFee}}Einbehalt: {{cancellationFee}}{{/if}}",
+    label: "Einbehalt vorhanden (Bedingung)",
+    description:
+      "Wahr, wenn ein Betrag einbehalten wird – Hinweis in den Zweigen anpassen",
+  },
+  {
+    name: "adminOverride",
+    placeholder:
+      "{{#if adminOverride}}manuell durch Administration{{else}}nach Regelwerk{{/if}}",
+    label: "Admin-Override (Bedingung)",
+    description:
+      "Wahr, wenn ein Admin den vorgeschlagenen Prozentsatz überschrieben hat",
+  },
+  {
+    name: "refundCalculations",
+    placeholder:
+      "{{#each refundCalculations}}Buchung {{bookingId}}: {{daysBeforeStartLabel}} Kalendertage vor Beginn, {{refundPercentage}} % Erstattung ({{refundAmount}}), {{calculationMode}}{{#unless @last}}<br />{{/unless}}{{/each}}",
+    label: "Erstattungsberechnungen (Sammel)",
+    description:
+      "Array der Einzelberechnungen bei Sammelstornos (bookingId, Tage, %, Betrag, Berechnungsart)",
   },
   {
     name: "customerBankDetails",
@@ -412,7 +491,7 @@ export const CANCELLATION_VARIABLES = [
     name: "bookingId",
     placeholder: "{{bookingId}}",
     label: "Buchungs-ID",
-    description: "ID der stornierten Buchung",
+    description: "ID der stornierten Buchung bzw. Gruppenbuchung",
   },
   {
     name: "totalAmount",
@@ -712,10 +791,20 @@ export const SAMPLE_DATA = {
     cancellationNumber: "S-2026-000007",
     originalInvoiceNumber: "R-2026-000123",
     originalInvoiceDate: "18.05.2026",
-    cancellationDate: "20.05.2026",
+    cancellationDate: "20.05.2026, 14:32",
     cancellationReason: "Kunde hat Buchung widerrufen",
     alreadyPaid: true,
+    daysBeforeStart: 20,
+    daysBeforeStartLabel: "20",
+    suggestedRefundPercentage: 100,
+    refundPercentage: 100,
+    appliedTierDays: 20,
+    calculationMode: "Automatisch nach Mandantenregel",
+    adminOverride: false,
+    isFullRefund: true,
+    hasCancellationFee: false,
     refundAmount: "120,00 €",
+    cancellationFee: "0,00 €",
     location: "Musterstadt",
     totalAmount: "-120,00 €",
     bookingId: "BK-987654",

--- a/src/components/Mail/templateVariables.js
+++ b/src/components/Mail/templateVariables.js
@@ -37,6 +37,52 @@ export const SNIPPET_VARIABLES = [
   },
 ];
 
+export const BOOKING_CANCEL_SNIPPET_VARIABLES = [
+  {
+    name: "hasRefundPreview",
+    placeholder: "{{#if hasRefundPreview}}...{{/if}}",
+    label: "Erstattung vorhanden",
+    description:
+      "Wahr, wenn die Buchung einen Erstattungsbetrag größer 0 € hat",
+  },
+  {
+    name: "refundAmountEur",
+    placeholder: "{{priceFormatted refundAmountEur}}",
+    label: "Erstattungsbetrag",
+    description: "Erstattungsbetrag als Zahl (mit Helper priceFormatted)",
+  },
+  {
+    name: "cancellationFeeEur",
+    placeholder: "{{priceFormatted cancellationFeeEur}}",
+    label: "Einbehalt",
+    description: "Einbehaltener Betrag (Stornogebühr) als Zahl",
+  },
+  {
+    name: "originalAmountEur",
+    placeholder: "{{priceFormatted originalAmountEur}}",
+    label: "Ursprungsbetrag",
+    description: "Ursprungsbetrag der Buchung als Zahl",
+  },
+  {
+    name: "refundPercentage",
+    placeholder: "{{refundPercentage}}",
+    label: "Erstattungsprozent",
+    description: "Angewandter Erstattungsprozentsatz (0–100)",
+  },
+  {
+    name: "hasCancellationFee",
+    placeholder: "{{#if hasCancellationFee}}...{{/if}}",
+    label: "Einbehalt vorhanden",
+    description: "Wahr, wenn ein Einbehalt größer 0 € anfällt",
+  },
+  {
+    name: "daysBeforeStart",
+    placeholder: "{{daysBeforeStart}}",
+    label: "Tage bis Beginn",
+    description: "Kalendertage bis zum Buchungsbeginn zum Berechnungszeitpunkt",
+  },
+];
+
 export const GENERIC_MAIL_VARIABLES = [
   {
     name: "title",
@@ -742,6 +788,13 @@ export const SAMPLE_DATA = {
     customerName: "Max Mustermann",
     currentDate: new Date().toLocaleDateString("de-DE"),
     customerContact: SAMPLE_CUSTOMER_CONTACT,
+    hasRefundPreview: true,
+    originalAmountEur: 120,
+    refundAmountEur: 60,
+    cancellationFeeEur: 60,
+    refundPercentage: 50,
+    daysBeforeStart: 10,
+    hasCancellationFee: true,
   },
   genericMail: {
     content:

--- a/src/components/PDF/PdfTemplateEditorDialog.vue
+++ b/src/components/PDF/PdfTemplateEditorDialog.vue
@@ -70,6 +70,19 @@
               :variables="catalog.variables"
               @change="onBlocksChange"
             />
+            <div
+              v-if="!(mode === 'expert' && !expertConfirmed)"
+              class="d-flex flex-wrap align-center mt-3"
+            >
+              <v-btn small outlined @click="resetToVisualDefault">
+                <v-icon small left>mdi-restore</v-icon>
+                Standardvorlage laden
+              </v-btn>
+              <span class="text-caption grey--text ml-3">
+                Ersetzt den aktuellen Inhalt durch die Standardvorlage
+                (entspricht dem Backend-Default).
+              </span>
+            </div>
             <v-alert
               v-if="mode === 'visual' && missingInBlocks.length"
               type="warning"
@@ -769,12 +782,17 @@ export default {
       this.mode = "expert";
     },
     startFromScratch() {
-      this.expertConfirmed = true;
+      this.resetToVisualDefault();
+      this.activeTab = 0;
+    },
+    resetToVisualDefault() {
       this.applyDefaultPageTemplates();
       this.blocks = this.makeDefaultBlocks();
       this.expertHtml = this.composeFromBlocks(this.blocks);
+      this.expertConfirmed = true;
       this.mode = "visual";
-      this.activeTab = 0;
+      this.previewSampleDataCache = null;
+      this.previewKey++;
     },
     resetToDefault() {
       this.applyDefaultPageTemplates();
@@ -782,6 +800,8 @@ export default {
       this.expertHtml = this.composeFromBlocks(this.blocks);
       this.expertConfirmed = true;
       this.mode = "expert";
+      this.previewSampleDataCache = null;
+      this.previewKey++;
     },
     composeOutput() {
       if (this.mode === "visual") {

--- a/src/components/PDF/pdfTemplateCatalog.js
+++ b/src/components/PDF/pdfTemplateCatalog.js
@@ -12,6 +12,8 @@ const COMMON_STYLES = `
       table { border-collapse: collapse; }
       .meta { text-align: right; font-size: 12px; color: #666; margin-bottom: 16px; }
       .info-box { padding: 12px; background: #f9f9f9; border-radius: 4px; margin: 12px 0; }
+      .cancellation-note { margin-top: 10px; padding: 10px; border-left: 4px solid #c0392b; background: #fdecea; font-size: 12px; line-height: 18px; }
+      .refund-note { margin-top: 10px; padding: 10px; border-left: 4px solid #2e7d32; background: #eaf5ea; font-size: 12px; line-height: 18px; }
       .booking-detail, .booked-items { width: 100%; }
       .booking-detail td, .booking-detail th,
       .booked-items td, .booked-items th { padding: 8px; border-bottom: 1px solid #ddd; }
@@ -256,6 +258,8 @@ function makeInvoiceDefaultBlocks() {
 }
 
 function makeCancellationDefaultBlocks() {
+  // Content mirrors the backend default template
+  // (default-cancellation-receipt.temp.html), adapted for the block editor.
   return [
     {
       type: "row",
@@ -283,43 +287,65 @@ function makeCancellationDefaultBlocks() {
             {
               type: "text",
               html:
-                `<p>Hiermit stornieren wir die Rechnung <strong>${chip("originalInvoiceNumber", "Original-Rechnungsnummer")}</strong> ` +
-                `vom ${chip("originalInvoiceDate", "Original-Rechnungsdatum")}.</p>`,
+                "<p>Sehr geehrte Damen und Herren,<br /><br />" +
+                `hiermit stornieren wir die Rechnung mit der Nummer <strong>${chip("originalInvoiceNumber", "Original-Rechnungsnummer")}</strong> vom ` +
+                `${chip("originalInvoiceDate", "Original-Rechnungsdatum")}. Die nachfolgend aufgeführten Positionen werden Ihnen ` +
+                "{{#if isFullRefund}}in voller Höhe{{else}}anteilig gemäß der nachfolgenden Berechnung{{/if}} gutgeschrieben.</p>",
               align: "left",
             },
             {
               type: "rawHtml",
               html:
-                "{{#if cancellationReason}}<p><strong>Grund:</strong> {{cancellationReason}}</p>{{/if}}",
+                "{{#if cancellationReason}}" +
+                "<div class=\"cancellation-note\">" +
+                "<strong>Grund der Stornierung:</strong> {{cancellationReason}}" +
+                "</div>" +
+                "{{/if}}",
+            },
+            {
+              type: "rawHtml",
+              html:
+                "<div class=\"cancellation-note\">" +
+                "<strong>Berechnung der Erstattung:</strong><br />" +
+                "Stornierungszeitpunkt: {{cancellationDate}}<br />" +
+                "{{#if refundCalculations}}" +
+                "{{#each refundCalculations}}" +
+                "Buchung {{bookingId}}: {{daysBeforeStartLabel}} Kalendertage vor Beginn, " +
+                "{{refundPercentage}} % Erstattung ({{refundAmount}})." +
+                "{{#unless @last}}<br />{{/unless}}" +
+                "{{/each}}" +
+                "{{else}}" +
+                "{{daysBeforeStartLabel}} Kalendertage vor Buchungsbeginn, " +
+                "{{refundPercentage}} % Erstattung." +
+                "{{/if}}" +
+                "</div>",
             },
             {
               type: "rawHtml",
               html:
                 "{{#if alreadyPaid}}" +
-                "<p>Der bereits gezahlte Betrag in Höhe von <strong>{{refundAmount}}</strong> wird Ihnen per {{refundMethod}} erstattet." +
+                "<div class=\"refund-note\">" +
+                "Der bereits gezahlte Betrag in Höhe von <strong>{{refundAmount}}</strong> wird Ihnen erstattet." +
+                "{{#if hasCancellationFee}} Der einbehaltene Betrag beläuft sich auf <strong>{{cancellationFee}}</strong>.{{/if}}" +
+                "</div>" +
                 "{{#if customerBankDetails}}{{{customerBankDetails}}}{{/if}}" +
-                "{{/if}}" +
-                "{{#unless alreadyPaid}}" +
-                "<p>Sofern noch keine Zahlung erfolgt ist, entfällt die Zahlungsverpflichtung aus der ursprünglichen Rechnung.</p>" +
-                "{{/unless}}",
+                "{{else}}" +
+                "<p>Sofern noch keine Zahlung erfolgt ist, reduziert sich die Zahlungsverpflichtung um " +
+                "<strong>{{refundAmount}}</strong>. " +
+                "{{#if isFullRefund}}Die ursprüngliche Rechnung <strong>{{originalInvoiceNumber}}</strong> wird damit vollständig aufgehoben." +
+                "{{else}}Der verbleibende Betrag in Höhe von <strong>{{cancellationFee}}</strong> bleibt bestehen.{{/if}}" +
+                "</p>" +
+                "{{/if}}",
             },
             {
               type: "rawHtml",
               html: "{{{mainContent}}}",
             },
             {
-              type: "rawHtml",
-              html:
-                "{{#if showBankDetails}}" +
-                "<div class=\"info-box\"><strong>Unsere Bankverbindung für Rückfragen:</strong><br />" +
-                "{{bank}}<br />IBAN: {{iban}}<br />BIC: {{bic}}</div>" +
-                "{{/if}}",
-            },
-            {
               type: "text",
               html:
-                `<p><strong>Gesamt-Stornobetrag: ${chip("totalAmount", "Gesamt-Stornobetrag")}</strong></p>`,
-              align: "right",
+                `<p>Bei Rückfragen zu dieser Stornorechnung wenden Sie sich bitte unter Angabe der Stornobelegnummer <strong>${chip("cancellationNumber", "Stornobelegnummer")}</strong> an uns.</p>`,
+              align: "left",
             },
             {
               type: "text",
@@ -399,7 +425,7 @@ export const PDF_TEMPLATE_CATALOG = {
     key: "cancellation",
     title: "Stornorechnungs-Vorlage",
     description:
-      "Vorlage für Einzel- und Sammel-Stornorechnungen. Pflichtvariablen: {{cancellationNumber}}, {{{invoiceAddress}}} sowie {{{mainContent}}} oder ein Tabellen-Partial ({{> pdfBookingItemsTable}} / {{> pdfAggregatedBookingsTable}}).",
+      "Vorlage für Einzel- und Sammel-Stornorechnungen. Pflichtvariablen: {{cancellationNumber}}, {{{invoiceAddress}}} sowie {{{mainContent}}} oder ein Tabellen-Partial ({{> pdfBookingItemsTable}} / {{> pdfAggregatedBookingsTable}}). Erstattungsstaffel: {{daysBeforeStartLabel}}, {{refundPercentage}}, {{cancellationFee}}, {{calculationMode}}, {{#if isFullRefund}} …",
     icon: "mdi-receipt-text-remove-outline",
     variables: CANCELLATION_VARIABLES,
     sampleData: SAMPLE_DATA.cancellation,
@@ -423,7 +449,7 @@ export const PDF_TEMPLATE_CATALOG = {
       return {
         headerHtml: "",
         footerHtml: makeDefaultPageFooter(
-          "Stornorechnung {{cancellationNumber}}",
+          "{{title}} {{cancellationNumber}}",
         ),
       };
     },

--- a/src/components/Tenant/Edit/TenantCancellationRefundTiersEditor.vue
+++ b/src/components/Tenant/Edit/TenantCancellationRefundTiersEditor.vue
@@ -1,0 +1,437 @@
+<template>
+  <BaseSection
+    :title="$t('tenant.cancellationRefundTiers.title')"
+    icon="mdi-cash-refund"
+  >
+    <v-row class="mb-1">
+      <v-col class="col-12 col-md-8">
+        <p class="text--secondary body-2 mb-0">
+          {{ $t("tenant.cancellationRefundTiers.description") }}
+        </p>
+      </v-col>
+      <v-col class="col-12 col-md-4 d-flex justify-end align-center">
+        <v-btn color="primary" @click="openCreate">
+          <v-icon left>mdi-plus</v-icon>
+          {{ $t("tenant.cancellationRefundTiers.add") }}
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <v-alert type="info" dense text icon="mdi-information-outline" class="mb-4">
+      {{ $t("tenant.cancellationRefundTiers.orderHint") }}
+    </v-alert>
+
+    <v-expansion-panels multiple>
+      <v-expansion-panel
+        v-for="(tier, index) in localTiers"
+        :key="`cancellation-refund-tier-${tier.daysBeforeStart}`"
+      >
+        <v-expansion-panel-header color="accent" expand-icon="mdi-menu-down">
+          <template v-slot:default>
+            <v-row no-gutters align="center" class="w-100">
+              <v-col class="col-5 d-flex align-center min-width-0">
+                <v-chip
+                  x-small
+                  color="indigo"
+                  text-color="white"
+                  label
+                  class="mr-2 flex-shrink-0"
+                >
+                  <v-icon x-small>mdi-calendar-clock</v-icon>
+                </v-chip>
+                <strong class="text-truncate min-width-0">
+                  {{
+                    $t("tenant.cancellationRefundTiers.tierTitle", {
+                      days: tier.daysBeforeStart,
+                    })
+                  }}
+                </strong>
+              </v-col>
+
+              <v-col class="col-4 d-flex align-center">
+                <v-chip
+                  x-small
+                  :color="refundColor(tier.refundPercentage)"
+                  text-color="white"
+                  label
+                >
+                  {{ tier.refundPercentage }} %
+                  {{ $t("tenant.cancellationRefundTiers.refundPercentage") }}
+                </v-chip>
+              </v-col>
+
+              <v-col class="col-3 d-flex justify-end align-center">
+                <v-tooltip bottom>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      icon
+                      small
+                      v-bind="attrs"
+                      v-on="on"
+                      @click.stop="openEdit(index)"
+                    >
+                      <v-icon>mdi-pencil</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>{{ $t("tenant.cancellationRefundTiers.edit") }}</span>
+                </v-tooltip>
+                <v-tooltip bottom>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      icon
+                      small
+                      color="error"
+                      v-bind="attrs"
+                      v-on="on"
+                      @click.stop="askRemove(index)"
+                    >
+                      <v-icon>mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>{{ $t("tenant.cancellationRefundTiers.remove") }}</span>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+          </template>
+        </v-expansion-panel-header>
+
+        <v-expansion-panel-content class="pt-2">
+          <div class="text-body-2">
+            {{
+              $t("tenant.cancellationRefundTiers.tierDescription", {
+                days: tier.daysBeforeStart,
+                percentage: tier.refundPercentage,
+              })
+            }}
+          </div>
+          <div
+            v-if="index === localTiers.length - 1"
+            class="text-caption text--secondary mt-2"
+          >
+            {{ $t("tenant.cancellationRefundTiers.lowestTierHint") }}
+          </div>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel v-if="!localTiers.length" disabled>
+        <v-expansion-panel-header>
+          {{ $t("tenant.cancellationRefundTiers.empty") }}
+        </v-expansion-panel-header>
+      </v-expansion-panel>
+    </v-expansion-panels>
+
+    <v-dialog v-model="dialogOpen" max-width="650" persistent>
+      <v-card class="refund-tier-dialog">
+        <v-card-title class="subtitle-1">
+          <v-icon left color="primary" small>mdi-cash-refund</v-icon>
+          {{
+            editingIndex >= 0
+              ? $t("tenant.cancellationRefundTiers.editTitle")
+              : $t("tenant.cancellationRefundTiers.createTitle")
+          }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text class="pt-4">
+          <v-form ref="dialogForm" v-model="dialogValid">
+            <v-row dense>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model.number="editingTier.daysBeforeStart"
+                  :label="$t('tenant.cancellationRefundTiers.daysBeforeStart')"
+                  :rules="daysRules"
+                  type="number"
+                  min="0"
+                  step="1"
+                  suffix="Tage"
+                  background-color="accent"
+                  filled
+                  dense
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model.number="editingTier.refundPercentage"
+                  :label="$t('tenant.cancellationRefundTiers.refundPercentage')"
+                  :rules="refundRules"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  suffix="%"
+                  background-color="accent"
+                  filled
+                  dense
+                />
+              </v-col>
+            </v-row>
+
+            <v-card outlined class="tier-preview pa-3 mt-2">
+              <div class="text-caption text--secondary mb-1">
+                <v-icon small left color="primary">mdi-eye-outline</v-icon>
+                {{ $t("tenant.cancellationRefundTiers.preview") }}
+              </div>
+              <div class="text-body-2">
+                {{
+                  $t("tenant.cancellationRefundTiers.tierDescription", {
+                    days: editingTier.daysBeforeStart ?? "–",
+                    percentage: editingTier.refundPercentage ?? "–",
+                  })
+                }}
+              </div>
+            </v-card>
+          </v-form>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="closeDialog">
+            {{ $t("tenant.cancellationRefundTiers.cancel") }}
+          </v-btn>
+          <v-btn color="primary" text :disabled="!canSave" @click="saveTier">
+            {{
+              editingIndex >= 0
+                ? $t("tenant.cancellationRefundTiers.save")
+                : $t("tenant.cancellationRefundTiers.create")
+            }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="confirmDelete.open" max-width="420">
+      <v-card>
+        <v-card-title class="subtitle-1">
+          {{ $t("tenant.cancellationRefundTiers.deleteTitle") }}
+        </v-card-title>
+        <v-card-text>
+          {{
+            $t("tenant.cancellationRefundTiers.deleteDescription", {
+              days: deletingTier?.daysBeforeStart,
+            })
+          }}
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="confirmDelete.open = false">
+            {{ $t("tenant.cancellationRefundTiers.cancel") }}
+          </v-btn>
+          <v-btn color="error" text @click="removeTier">
+            {{ $t("tenant.cancellationRefundTiers.remove") }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </BaseSection>
+</template>
+
+<script>
+import BaseSection from "@/components/commons/BaseSection.vue";
+
+function cloneTiers(tiers) {
+  return (Array.isArray(tiers) ? tiers : []).map((tier) => ({
+    daysBeforeStart: tier.daysBeforeStart,
+    refundPercentage: tier.refundPercentage,
+  }));
+}
+
+function sortTiers(tiers) {
+  return [...tiers].sort(
+    (left, right) =>
+      Number(right.daysBeforeStart) - Number(left.daysBeforeStart)
+  );
+}
+
+export default {
+  name: "TenantCancellationRefundTiersEditor",
+  components: { BaseSection },
+  props: {
+    tiers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      localTiers: cloneTiers(this.tiers),
+      dialogOpen: false,
+      dialogValid: false,
+      editingIndex: -1,
+      editingTier: {
+        daysBeforeStart: 0,
+        refundPercentage: 100,
+      },
+      confirmDelete: {
+        open: false,
+        index: -1,
+      },
+    };
+  },
+  computed: {
+    deletingTier() {
+      return this.localTiers[this.confirmDelete.index] || null;
+    },
+    daysRules() {
+      return [
+        (value) => this.isPresent(value) || this.$t("validation.required"),
+        (value) =>
+          Number.isInteger(Number(value)) ||
+          this.$t("validation.integerRequired"),
+        (value) =>
+          Number(value) >= 0 ||
+          this.$t("tenant.cancellationRefundTiers.nonNegativeDays"),
+        (value) =>
+          !this.hasDuplicateDays(value) ||
+          this.$t("tenant.cancellationRefundTiers.uniqueDays"),
+      ];
+    },
+    refundRules() {
+      return [
+        (value) => this.isPresent(value) || this.$t("validation.required"),
+        (value) =>
+          Number.isInteger(Number(value)) ||
+          this.$t("validation.integerRequired"),
+        (value) =>
+          (Number(value) >= 0 && Number(value) <= 100) ||
+          this.$t("tenant.cancellationRefundTiers.percentageRange"),
+        () =>
+          this.isCandidateMonotonic ||
+          this.$t("tenant.cancellationRefundTiers.monotonic"),
+      ];
+    },
+    candidateTiers() {
+      const tiers = cloneTiers(this.localTiers);
+      const candidate = {
+        daysBeforeStart: Number(this.editingTier.daysBeforeStart),
+        refundPercentage: Number(this.editingTier.refundPercentage),
+      };
+      if (this.editingIndex >= 0) {
+        tiers.splice(this.editingIndex, 1, candidate);
+      } else {
+        tiers.push(candidate);
+      }
+      return sortTiers(tiers);
+    },
+    isCandidateMonotonic() {
+      return this.candidateTiers.every((tier, index, tiers) => {
+        if (index === 0) return true;
+        return (
+          Number(tier.refundPercentage) <=
+          Number(tiers[index - 1].refundPercentage)
+        );
+      });
+    },
+    canSave() {
+      return (
+        this.dialogValid &&
+        !this.hasDuplicateDays(this.editingTier.daysBeforeStart) &&
+        this.isCandidateMonotonic
+      );
+    },
+  },
+  watch: {
+    tiers: {
+      deep: true,
+      handler(tiers) {
+        const normalized = cloneTiers(tiers);
+        if (JSON.stringify(normalized) !== JSON.stringify(this.localTiers)) {
+          this.localTiers = normalized;
+        }
+      },
+    },
+  },
+  methods: {
+    isPresent(value) {
+      return value !== "" && value !== null && value !== undefined;
+    },
+    hasDuplicateDays(value) {
+      return this.localTiers.some(
+        (tier, index) =>
+          index !== this.editingIndex &&
+          Number(tier.daysBeforeStart) === Number(value)
+      );
+    },
+    refundColor(percentage) {
+      if (percentage >= 100) return "success";
+      if (percentage <= 0) return "error";
+      return "primary";
+    },
+    openCreate() {
+      const sorted = sortTiers(this.localTiers);
+      const highest = sorted[0];
+      this.editingIndex = -1;
+      this.editingTier = {
+        daysBeforeStart: highest ? Number(highest.daysBeforeStart || 0) + 1 : 0,
+        refundPercentage: highest
+          ? Number(highest.refundPercentage ?? 100)
+          : 100,
+      };
+      this.dialogOpen = true;
+      this.$nextTick(() => this.$refs.dialogForm?.resetValidation());
+    },
+    openEdit(index) {
+      this.editingIndex = index;
+      this.editingTier = { ...this.localTiers[index] };
+      this.dialogOpen = true;
+      this.$nextTick(() => this.$refs.dialogForm?.resetValidation());
+    },
+    closeDialog() {
+      this.dialogOpen = false;
+      this.editingIndex = -1;
+      this.$refs.dialogForm?.resetValidation();
+    },
+    saveTier() {
+      if (!this.$refs.dialogForm?.validate() || !this.canSave) return;
+      const tier = {
+        daysBeforeStart: Number(this.editingTier.daysBeforeStart),
+        refundPercentage: Number(this.editingTier.refundPercentage),
+      };
+      if (this.editingIndex >= 0) {
+        this.localTiers.splice(this.editingIndex, 1, tier);
+      } else {
+        this.localTiers.push(tier);
+      }
+      this.emitTiers();
+      this.closeDialog();
+    },
+    askRemove(index) {
+      this.confirmDelete = { open: true, index };
+    },
+    removeTier() {
+      if (this.confirmDelete.index >= 0) {
+        this.localTiers.splice(this.confirmDelete.index, 1);
+        this.emitTiers();
+      }
+      this.confirmDelete = { open: false, index: -1 };
+    },
+    emitTiers() {
+      this.localTiers = sortTiers(this.localTiers);
+      this.$emit("update:tiers", cloneTiers(this.localTiers));
+    },
+  },
+};
+</script>
+
+<style scoped>
+.min-width-0 {
+  min-width: 0;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.tier-preview {
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 4px !important;
+}
+
+.theme--dark .tier-preview {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.refund-tier-dialog >>> .v-input__control > .v-input__slot {
+  border-radius: 4px !important;
+}
+</style>

--- a/src/components/Tenant/Edit/TenantEditBooking.vue
+++ b/src/components/Tenant/Edit/TenantEditBooking.vue
@@ -1,16 +1,20 @@
 <script>
 import BaseSection from "@/components/commons/BaseSection.vue";
+import TenantCancellationRefundTiersEditor from "@/components/Tenant/Edit/TenantCancellationRefundTiersEditor.vue";
 
 export default {
   name: "TenantEditBooking",
-  components: { BaseSection },
+  components: { TenantCancellationRefundTiersEditor, BaseSection },
   props: {
     tenant: { type: Object, required: true },
   },
   data() {
     return {
       valid: false,
-      localTenant: { ...this.tenant },
+      localTenant: {
+        ...this.tenant,
+        cancellationRefundTiers: this.tenant.cancellationRefundTiers || [],
+      },
       validationRules: {
         required: [(v) => !!v || "Pflichtfeld"],
         mail: [
@@ -33,13 +37,20 @@ export default {
     tenant: {
       deep: true,
       handler(v) {
-        this.localTenant = { ...v };
+        this.localTenant = {
+          ...v,
+          cancellationRefundTiers: v.cancellationRefundTiers || [],
+        };
       },
     },
   },
   methods: {
     emitTenant() {
       this.$emit("update:tenant", this.localTenant);
+    },
+    updateRefundTiers(tiers) {
+      this.$set(this.localTenant, "cancellationRefundTiers", tiers);
+      this.emitTenant();
     },
     async validate() {
       return this.$refs.form ? this.$refs.form.validate() : true;
@@ -52,51 +63,58 @@ export default {
 </script>
 
 <template>
-  <BaseSection title="Buchungskonfiguration" icon="mdi-calendar">
-    <v-row>
-      <v-col class="col-12 col-md-6">
-        <v-text-field
-          background-color="accent"
-          filled
-          dense
-          label="Vorausbuchungen möglich bis"
-          type="number"
-          suffix="Monate"
-          v-model="localTenant.maxBookingAdvanceInMonths"
-          @input="emitTenant()"
-        >
-        </v-text-field>
-      </v-col>
-    </v-row>
-    <v-switch
-      v-model="localTenant.notifyOnNewBooking"
-      color="primary"
-      hint="Sofern aktiviert, erhält der Mandant eine E-Mail bei jeder neuen Buchung."
-      persistent-hint
-      label="Benachrichtigung bei neuer Buchung"
-      class="mt-2"
-      @change="emitTenant()"
-    ></v-switch>
-    <v-switch
-      v-model="localTenant.notifySupervisorsOnBooking"
-      color="primary"
-      hint="Sofern aktiviert, werden bei Buchungen die an den Mitgliedern hinterlegten Benachrichtigungsempfänger (z. B. Vorgesetzte) automatisch per E-Mail informiert."
-      persistent-hint
-      label="Vorgesetzte bei Buchung informieren"
-      class="mt-2"
-      @change="emitTenant()"
-    ></v-switch>
-    <v-switch
-      v-model="localTenant.enablePublicStatusView"
-      color="primary"
-      hint="Sofern aktiviert, kann der Status einer Buchung öffentlich abgefragt werden."
-      persistent-hint
-      label="Öffentlicher Buchungsstatus"
-      class="mt-2"
-      @change="emitTenant()"
-    >
-    </v-switch>
-  </BaseSection>
+  <v-form ref="form" v-model="valid">
+    <BaseSection title="Buchungskonfiguration" icon="mdi-calendar">
+      <v-row>
+        <v-col class="col-12 col-md-6">
+          <v-text-field
+            background-color="accent"
+            filled
+            dense
+            label="Vorausbuchungen möglich bis"
+            type="number"
+            suffix="Monate"
+            v-model="localTenant.maxBookingAdvanceInMonths"
+            @input="emitTenant()"
+          >
+          </v-text-field>
+        </v-col>
+      </v-row>
+      <v-switch
+        v-model="localTenant.notifyOnNewBooking"
+        color="primary"
+        hint="Sofern aktiviert, erhält der Mandant eine E-Mail bei jeder neuen Buchung."
+        persistent-hint
+        label="Benachrichtigung bei neuer Buchung"
+        class="mt-2"
+        @change="emitTenant()"
+      ></v-switch>
+      <v-switch
+        v-model="localTenant.notifySupervisorsOnBooking"
+        color="primary"
+        hint="Sofern aktiviert, werden bei Buchungen die an den Mitgliedern hinterlegten Benachrichtigungsempfänger (z. B. Vorgesetzte) automatisch per E-Mail informiert."
+        persistent-hint
+        label="Vorgesetzte bei Buchung informieren"
+        class="mt-2"
+        @change="emitTenant()"
+      ></v-switch>
+      <v-switch
+        v-model="localTenant.enablePublicStatusView"
+        color="primary"
+        hint="Sofern aktiviert, kann der Status einer Buchung öffentlich abgefragt werden."
+        persistent-hint
+        label="Öffentlicher Buchungsstatus"
+        class="mt-2"
+        @change="emitTenant()"
+      >
+      </v-switch>
+    </BaseSection>
+
+    <TenantCancellationRefundTiersEditor
+      :tiers="localTenant.cancellationRefundTiers"
+      @update:tiers="updateRefundTiers"
+    />
+  </v-form>
 </template>
 
 <style scoped></style>

--- a/src/entities/tenant.js
+++ b/src/entities/tenant.js
@@ -30,6 +30,7 @@ class Tenant {
     paymentPurposeSuffix,
     applications,
     maxBookingAdvanceInMonths,
+    cancellationRefundTiers,
     defaultEventCreationMode,
     enablePublicStatusView,
     ownerUserIds,
@@ -67,6 +68,7 @@ class Tenant {
     this.paymentPurposeSuffix = paymentPurposeSuffix;
     this.applications = applications || [];
     this.maxBookingAdvanceInMonths = maxBookingAdvanceInMonths;
+    this.cancellationRefundTiers = cancellationRefundTiers || [];
     this.defaultEventCreationMode = defaultEventCreationMode || "";
     this.enablePublicStatusView = enablePublicStatusView;
     this.ownerUserIds = ownerUserIds || [];

--- a/src/language/de/translations.json
+++ b/src/language/de/translations.json
@@ -79,6 +79,10 @@
       "message": "Bitte überprüfen Sie Ihre Eingaben und versuchen Sie es erneut."
     }
   },
+  "validation": {
+    "required": "Pflichtfeld",
+    "integerRequired": "Ganzzahl erforderlich"
+  },
   "bookable": {
     "delete": {
       "success": {
@@ -210,6 +214,32 @@
         "title": "Fehler beim Aktualisieren",
         "message": "Der Mandantenstatus konnte nicht aktualisiert werden."
       }
+    },
+    "cancellationRefundTiers": {
+      "title": "Erstattungsstaffel bei Stornierungen",
+      "description": "Legen Sie fest, welcher Anteil des Buchungspreises abhängig von den verbleibenden Kalendertagen bis zum Buchungsbeginn erstattet wird. Die Regelung gilt für alle Buchungsobjekte dieses Mandanten.",
+      "empty": "Noch keine Erstattungsstufen definiert. Ohne Staffel werden 100 % erstattet.",
+      "orderHint": "Die Stufen werden automatisch nach dem Vorlauf sortiert. Unterhalb der niedrigsten Stufe gilt deren Erstattung weiter.",
+      "daysBeforeStart": "Ab Tagen vor Buchungsbeginn",
+      "refundPercentage": "Erstattung",
+      "add": "Stufe hinzufügen",
+      "edit": "Bearbeiten",
+      "remove": "Stufe entfernen",
+      "tierTitle": "Ab {days} Tagen",
+      "tierDescription": "Ab {days} Kalendertagen vor Buchungsbeginn werden {percentage} % des Buchungspreises erstattet.",
+      "lowestTierHint": "Diese Erstattung gilt auch bei einem geringeren Vorlauf bis unmittelbar vor dem Buchungsbeginn.",
+      "createTitle": "Neue Erstattungsstufe anlegen",
+      "editTitle": "Erstattungsstufe bearbeiten",
+      "preview": "Vorschau",
+      "cancel": "Abbrechen",
+      "create": "Anlegen",
+      "save": "Speichern",
+      "deleteTitle": "Erstattungsstufe löschen?",
+      "deleteDescription": "Die Erstattungsstufe ab {days} Tagen wird entfernt.",
+      "nonNegativeDays": "Der Wert darf nicht negativ sein",
+      "uniqueDays": "Für diese Tagesgrenze existiert bereits eine Stufe",
+      "percentageRange": "Der Wert muss zwischen 0 und 100 liegen",
+      "monotonic": "Mit größerem Vorlauf darf die Erstattung nicht geringer werden."
     }
   },
 
@@ -242,7 +272,53 @@
       "error": {
         "title": "Fehler beim Löschen",
         "message": "Die Buchung konnte nicht gelöscht werden."
+      },
+      "requires-rejection": {
+        "title": "Stornierung erforderlich",
+        "message": "Bestätigte oder bezahlte Buchungen können nicht gelöscht werden. Bitte stornieren Sie die Buchung."
       }
+    },
+    "reject": {
+      "success": {
+        "title": "Erfolgreich storniert",
+        "message": "Die Buchung wurde erfolgreich storniert."
+      },
+      "error": {
+        "title": "Fehler beim Stornieren",
+        "message": "Die Buchung konnte nicht storniert werden."
+      }
+    },
+    "unreject": {
+      "success": {
+        "title": "Stornierung aufgehoben",
+        "message": "Die Buchung ist wieder aktiv."
+      },
+      "error": {
+        "title": "Fehler beim Aufheben",
+        "message": "Die Stornierung konnte nicht rückgängig gemacht werden."
+      }
+    },
+    "cancellationRefund": {
+      "title": "Erstattungsvorschau",
+      "auditTitle": "Erstattung bei Stornierung",
+      "originalAmount": "Ursprungsbetrag",
+      "refundAmount": "Erstattung",
+      "cancellationFee": "Einbehalt",
+      "refundShare": "{percentage} % Erstattung",
+      "cancelledAt": "Storniert am",
+      "auditOverride": "Bei {days} Kalendertagen bis zum Beginn schlug die Mandantenregel {suggested} % vor. Angewendet wurden {applied} % (Admin-Überschreibung).",
+      "booking": "Buchung",
+      "days": "Tage",
+      "policyPercentage": "Vorschlag",
+      "override": "Erstattung manuell überschreiben",
+      "overridePercentage": "Einheitliche Erstattung",
+      "percentageRange": "Der Wert muss zwischen 0 und 100 liegen",
+      "singlePolicy": "Bei {days} Kalendertagen bis zum Beginn schlägt die Mandantenregel {percentage} % Erstattung vor.",
+      "groupPolicySingle": "Die Mandantenregel schlägt für alle Buchungen der Serie {percentage} % Erstattung vor.",
+      "groupPolicyMixed": "Die Mandantenregel ergibt je nach Buchungsbeginn unterschiedliche Erstattungswerte. Ohne Überschreibung werden die Einzelwerte angewendet.",
+      "previewError": "Die Erstattungsvorschau konnte nicht geladen werden.",
+      "cancelGroup": "Gesamte Serie stornieren",
+      "cancelSingle": "Nur diese Buchung stornieren"
     },
     "create": {
       "success": {

--- a/src/language/de/translations.json
+++ b/src/language/de/translations.json
@@ -321,7 +321,15 @@
       "previewError": "Die Erstattungsvorschau konnte nicht geladen werden.",
       "finalAmountHint": "Der endgültige Erstattungsbetrag wird zum Zeitpunkt Ihrer Bestätigung berechnet.",
       "cancelGroup": "Gesamte Serie stornieren",
-      "cancelSingle": "Nur diese Buchung stornieren"
+      "cancelSingle": "Nur diese Buchung stornieren",
+      "bankDetailsTitle": "Bankverbindung des Kunden (optional)",
+      "bankDetailsHintSingle": "Diese Buchung wurde bereits bezahlt{amount}. Sie können optional die Bankverbindung des Kunden angeben.",
+      "bankDetailsHintGroup": "Mindestens eine Buchung der Serie wurde bereits bezahlt{amount}. Sie können optional die Bankverbindung des Kunden für die Sammel-Stornorechnung angeben.",
+      "accountHolder": "Kontoinhaber (optional)",
+      "iban": "IBAN (optional)",
+      "ibanHint": "z. B. DE89 3704 0044 0532 0130 00",
+      "bic": "BIC (optional)",
+      "bankName": "Name der Bank (optional)"
     },
     "create": {
       "success": {

--- a/src/language/de/translations.json
+++ b/src/language/de/translations.json
@@ -300,6 +300,7 @@
     },
     "cancellationRefund": {
       "title": "Erstattungsvorschau",
+      "expectedTitle": "Erwartete Erstattung",
       "auditTitle": "Erstattung bei Stornierung",
       "originalAmount": "Ursprungsbetrag",
       "refundAmount": "Erstattung",
@@ -314,9 +315,11 @@
       "overridePercentage": "Einheitliche Erstattung",
       "percentageRange": "Der Wert muss zwischen 0 und 100 liegen",
       "singlePolicy": "Bei {days} Kalendertagen bis zum Beginn schlägt die Mandantenregel {percentage} % Erstattung vor.",
+      "userPolicySummary": "Bei {days} Kalendertagen bis zum Beginn beträgt die Erstattung {percentage} %.",
       "groupPolicySingle": "Die Mandantenregel schlägt für alle Buchungen der Serie {percentage} % Erstattung vor.",
       "groupPolicyMixed": "Die Mandantenregel ergibt je nach Buchungsbeginn unterschiedliche Erstattungswerte. Ohne Überschreibung werden die Einzelwerte angewendet.",
       "previewError": "Die Erstattungsvorschau konnte nicht geladen werden.",
+      "finalAmountHint": "Der endgültige Erstattungsbetrag wird zum Zeitpunkt Ihrer Bestätigung berechnet.",
       "cancelGroup": "Gesamte Serie stornieren",
       "cancelSingle": "Nur diese Buchung stornieren"
     },

--- a/src/services/api/ApiBookingService.js
+++ b/src/services/api/ApiBookingService.js
@@ -69,6 +69,23 @@ export default {
     );
     return response.data;
   },
+  async getPublicCancellationRefundPreview(id, tenantId, name) {
+    const t = tenantId || store.getters["tenants/currentTenantId"];
+    const response = await ApiClient.get(
+      `api/${t}/bookings/${id}/cancellation-refund-preview/public`,
+      {
+        params: { name },
+      }
+    );
+    return response.data;
+  },
+  async getHookCancellationRefundPreview(id, tenantId, hookId) {
+    const t = tenantId || store.getters["tenants/currentTenantId"];
+    const response = await ApiClient.get(
+      `api/${t}/bookings/${id}/hooks/${hookId}/cancellation-refund-preview`
+    );
+    return response.data;
+  },
   rejectBooking(
     id,
     tenantId,

--- a/src/services/api/ApiBookingService.js
+++ b/src/services/api/ApiBookingService.js
@@ -27,7 +27,7 @@ export default {
   ) {
     const t = tenant || store.getters["tenants/currentTenantId"];
     const irb = includeRelatedBookables || false;
-    const ipb = includeParentBookables || false
+    const ipb = includeParentBookables || false;
     const po = publicOnly || false;
 
     //TODO: check if typo-correction interferes anywhere
@@ -62,7 +62,21 @@ export default {
     );
     return response.data;
   },
-  rejectBooking(id, tenantId, reason, skipCancellation, bankDetails) {
+  async getCancellationRefundPreview(id, tenantId) {
+    const t = tenantId || store.getters["tenants/currentTenantId"];
+    const response = await ApiClient.get(
+      `api/${t}/bookings/${id}/cancellation-refund-preview`
+    );
+    return response.data;
+  },
+  rejectBooking(
+    id,
+    tenantId,
+    reason,
+    skipCancellation,
+    bankDetails,
+    refundPercentage
+  ) {
     const t = tenantId || store.getters["tenants/currentTenantId"];
     const payload = {
       reason: reason,
@@ -71,10 +85,10 @@ export default {
     if (bankDetails) {
       payload.bankDetails = bankDetails;
     }
-    return ApiClient.post(
-      `api/${t}/bookings/${id}/reject?skipCancellation}`,
-      payload
-    );
+    if (refundPercentage !== undefined) {
+      payload.refundPercentage = refundPercentage;
+    }
+    return ApiClient.post(`api/${t}/bookings/${id}/reject`, payload);
   },
   requestRejectBooking(id, tenantId, reason, bankDetails) {
     const t = tenantId || store.getters["tenants/currentTenantId"];

--- a/src/services/api/ApiGroupBookingService.js
+++ b/src/services/api/ApiGroupBookingService.js
@@ -34,6 +34,7 @@ export default {
     groupBookingId,
     reason,
     skipCancellation,
+    bankDetails,
     refundPercentage
   ) {
     const t = tenantId || store.getters["tenants/currentTenantId"];
@@ -41,6 +42,9 @@ export default {
       reason: reason,
       skipCancellation: skipCancellation,
     };
+    if (bankDetails) {
+      payload.bankDetails = bankDetails;
+    }
     if (refundPercentage !== undefined) {
       payload.refundPercentage = refundPercentage;
     }

--- a/src/services/api/ApiGroupBookingService.js
+++ b/src/services/api/ApiGroupBookingService.js
@@ -22,11 +22,31 @@ export default {
     });
     return response.data;
   },
-  async rejectGroupBooking(tenantId, groupBookingId, reason, skipCancellation) {
+  async getCancellationRefundPreview(tenantId, groupBookingId) {
     const t = tenantId || store.getters["tenants/currentTenantId"];
+    const response = await ApiClient.get(
+      `api/${t}/group-bookings/${groupBookingId}/cancellation-refund-preview`
+    );
+    return response.data;
+  },
+  async rejectGroupBooking(
+    tenantId,
+    groupBookingId,
+    reason,
+    skipCancellation,
+    refundPercentage
+  ) {
+    const t = tenantId || store.getters["tenants/currentTenantId"];
+    const payload = {
+      reason: reason,
+      skipCancellation: skipCancellation,
+    };
+    if (refundPercentage !== undefined) {
+      payload.refundPercentage = refundPercentage;
+    }
     const response = await ApiClient.post(
       `api/${t}/group-bookings/${groupBookingId}/reject`,
-      { reason: reason, skipCancellation: skipCancellation }
+      payload
     );
     return response.data;
   },

--- a/src/utils/cancellationRefund.js
+++ b/src/utils/cancellationRefund.js
@@ -1,0 +1,20 @@
+export function getCancellationRefundAudit(booking) {
+  if (!booking?.isRejected) {
+    return null;
+  }
+
+  if (booking.cancellationRefund) {
+    return booking.cancellationRefund;
+  }
+
+  const attachments = Array.isArray(booking.attachments)
+    ? booking.attachments
+    : [];
+  const cancellationAttachments = attachments
+    .filter((item) => item.type === "cancellation" && item.cancellation)
+    .sort(
+      (left, right) => Number(right.timeCreated || 0) - Number(left.timeCreated || 0)
+    );
+
+  return cancellationAttachments[0]?.cancellation || null;
+}

--- a/src/views/Bookings.vue
+++ b/src/views/Bookings.vue
@@ -890,6 +890,7 @@ export default {
       id,
       rejectReason,
       skipCancellation,
+      bankDetails,
       refundPercentage
     ) {
       const groupBooking = this.api.groupBookings.find((groupBooking) =>
@@ -905,6 +906,7 @@ export default {
           groupBooking.id,
           rejectReason,
           skipCancellation,
+          bankDetails,
           refundPercentage
         );
 

--- a/src/views/Bookings.vue
+++ b/src/views/Bookings.vue
@@ -228,6 +228,7 @@
     <BookingRejectConformationDialog
       :to-reject="selectedBooking"
       :open="openRejectDialog"
+      :loading="loading"
       @close="onCloseRejectDialog"
       @reject-booking="rejectBooking"
     />
@@ -272,6 +273,7 @@
     />
     <GroupBookingRejectConformationDialog
       :to-reject="selectedBooking"
+      :group-booking-id="selectedGroupBooking?.id"
       :open="openRejectGroupBookingDialog"
       :in-progress="loading"
       :error="errors.reject"
@@ -283,6 +285,8 @@
       v-if="selectedBooking.id"
       :booking-id="selectedBooking.id"
       :open="openDeleteGroupBookingDialog"
+      :single-delete-disabled="isSelectedBookingHardDeleteBlocked"
+      :group-delete-disabled="isSelectedGroupHardDeleteBlocked"
       @close="closeDialog('deleteGroupBooking')"
       @delete-single-booking="deleteBooking"
       @delete-group-booking="deleteGroupBooking"
@@ -414,6 +418,18 @@ export default {
     },
     hasActiveBookingTypeFilter() {
       return this.bookingTypeFilter !== "all";
+    },
+    isSelectedBookingHardDeleteBlocked() {
+      return !!(
+        this.selectedBooking?.isCommitted || this.selectedBooking?.isPayed
+      );
+    },
+    isSelectedGroupHardDeleteBlocked() {
+      if (!this.selectedGroupBooking?.bookingIds) return false;
+      return this.selectedGroupBooking.bookingIds.some((bookingId) => {
+        const booking = this.api.bookings.find((item) => item.id === bookingId);
+        return booking?.isCommitted || booking?.isPayed;
+      });
     },
     mappedBookings() {
       return this.api.bookings.map((booking) => {
@@ -630,6 +646,13 @@ export default {
       }
     },
     async deleteBooking(bookingId) {
+      const booking = this.api.bookings.find((item) => item.id === bookingId);
+      if (booking?.isCommitted || booking?.isPayed) {
+        await this.addToast(
+          ToastService.createToast("booking.delete.requires-rejection", "error")
+        );
+        return;
+      }
       const optionId = ProcessingService.showOverlay("Lösche Buchung...");
       try {
         await this.startLoading("delete-booking");
@@ -647,6 +670,16 @@ export default {
       const groupBooking = this.api.groupBookings.find((groupBooking) =>
         groupBooking.bookingIds.includes(bookingId)
       );
+      const hasProtectedBooking = groupBooking.bookingIds.some((id) => {
+        const booking = this.api.bookings.find((item) => item.id === id);
+        return booking?.isCommitted || booking?.isPayed;
+      });
+      if (hasProtectedBooking) {
+        await this.addToast(
+          ToastService.createToast("booking.delete.requires-rejection", "error")
+        );
+        return;
+      }
       const optionId = ProcessingService.showOverlay("Lösche Serienbuchung...");
       try {
         await this.startLoading("delete-booking");
@@ -817,7 +850,13 @@ export default {
         ProcessingService.hide(operationId);
       }
     },
-    async rejectBooking(id, rejectReason, skipCancellation, bankDetails) {
+    async rejectBooking(
+      id,
+      rejectReason,
+      skipCancellation,
+      bankDetails,
+      refundPercentage
+    ) {
       const operationId = ProcessingService.showOverlay(
         "Buchung wird abgelehnt..."
       );
@@ -828,18 +867,31 @@ export default {
           this.tenantId,
           rejectReason,
           skipCancellation,
-          bankDetails
+          bankDetails,
+          refundPercentage
+        );
+        await this.addToast(
+          ToastService.createToast("booking.reject.success", "success")
         );
         await this.fetchBookings();
         await this.fetchGroupBookings();
         this.openRejectDialog = false;
         this.openRejectGroupBookingDialog = false;
+      } catch (error) {
+        await this.addToast(
+          ToastService.createToast("booking.reject.error", "error")
+        );
       } finally {
         await this.stopLoading("reject-booking");
         ProcessingService.hide(operationId);
       }
     },
-    async rejectGroupBooking(id, rejectReason, skipCancellation) {
+    async rejectGroupBooking(
+      id,
+      rejectReason,
+      skipCancellation,
+      refundPercentage
+    ) {
       const groupBooking = this.api.groupBookings.find((groupBooking) =>
         groupBooking.bookingIds.includes(id)
       );
@@ -852,7 +904,8 @@ export default {
           null,
           groupBooking.id,
           rejectReason,
-          skipCancellation
+          skipCancellation,
+          refundPercentage
         );
 
         if (!response.success) {
@@ -866,6 +919,14 @@ export default {
           await this.fetchGroupBookings();
           this.openRejectGroupBookingDialog = false;
         }
+      } catch (error) {
+        this.errors.reject =
+          error?.response?.data === "invalid_refund_percentage"
+            ? this.$t("booking.cancellationRefund.percentageRange")
+            : this.$t("group-booking.reject.error.message");
+        await this.addToast(
+          ToastService.createToast("group-booking.reject.error", "error")
+        );
       } finally {
         await this.stopLoading("reject-booking");
         ProcessingService.hide(operationId);
@@ -923,8 +984,10 @@ export default {
         this.api.bookings.find((booking) => booking.id === bookingId)
       );
       if (hasGroupBooking) {
+        this.selectedGroupBooking = Object.assign({}, hasGroupBooking);
         this.openDeleteGroupBookingDialog = true;
       } else {
+        this.selectedGroupBooking = null;
         this.openDeleteDialog = true;
       }
     },
@@ -937,8 +1000,10 @@ export default {
         this.api.bookings.find((booking) => booking.id === bookingId)
       );
       if (hasGroupBooking) {
+        this.selectedGroupBooking = Object.assign({}, hasGroupBooking);
         this.openRejectGroupBookingDialog = true;
       } else {
+        this.selectedGroupBooking = null;
         this.openRejectDialog = true;
       }
     },

--- a/src/views/RequestRejectBooking.vue
+++ b/src/views/RequestRejectBooking.vue
@@ -91,6 +91,8 @@
             hint="Bitte geben Sie Ihren Namen ein, so wie er auch in der Buchung hinterlegt wurde."
             :rules="[(v) => !!v || 'Bitte geben Sie Ihren Namen ein.']"
             persistent-hint
+            @blur="loadRefundPreview"
+            @input="onVerificationNameInput"
           ></v-text-field>
 
           <v-textarea
@@ -105,6 +107,33 @@
             class="mt-3"
           ></v-textarea>
 
+          <div v-if="showRefundPanel" class="text-left mt-2">
+            <v-skeleton-loader
+              v-if="loadingRefundPreview"
+              type="list-item-three-line"
+              class="mb-2"
+            />
+            <CancellationRefundPanel
+              v-else-if="refundPreview"
+              show-divider
+              :title="$t('booking.cancellationRefund.expectedTitle')"
+              :original-amount-eur="refundPreview.originalAmountEur"
+              :refund-amount-eur="refundPreview.refundAmountEur"
+              :cancellation-fee-eur="refundPreview.cancellationFeeEur"
+              :policy-summary="refundPolicySummary"
+              :footer="$t('booking.cancellationRefund.finalAmountHint')"
+            />
+            <v-alert
+              v-else-if="refundPreviewError"
+              type="warning"
+              text
+              dense
+              class="mt-3 mb-0"
+            >
+              {{ $t("booking.cancellationRefund.previewError") }}
+            </v-alert>
+          </div>
+
           <div v-if="requiresBankDetails" class="text-left mt-4">
             <v-divider class="mb-4"></v-divider>
             <p class="text-subtitle-2 font-weight-bold mb-1">
@@ -112,7 +141,11 @@
             </p>
             <p class="text-caption mb-3">
               Diese Buchung wurde bereits bezahlt
-              <span v-if="bookingStatus && bookingStatus.priceEur != null">
+              <span v-if="formattedExpectedRefund">
+                (erwartete Erstattung: {{ formattedExpectedRefund }})</span
+              ><span
+                v-else-if="bookingStatus && bookingStatus.priceEur != null"
+              >
                 (Betrag: {{ formattedPrice }})</span
               >. Sie können optional Ihre Bankverbindung angeben, um die
               Rückerstattung zu vereinfachen.
@@ -187,6 +220,8 @@
 
 <script>
 import ApiBookingService from "@/services/api/ApiBookingService";
+import CancellationRefundPanel from "@/components/Booking/CancellationRefundPanel.vue";
+import FormatService from "@/services/FormatService";
 
 const IBAN_REGEX = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$/;
 const BIC_REGEX = /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
@@ -221,6 +256,7 @@ function isValidIban(value) {
 
 export default {
   name: "RequestRejectBooking",
+  components: { CancellationRefundPanel },
   props: {
     tenantId: {
       type: String,
@@ -239,6 +275,9 @@ export default {
       loadingStatus: true,
       statusError: false,
       bookingStatus: null,
+      refundPreview: null,
+      loadingRefundPreview: false,
+      refundPreviewError: false,
       bankDetails: {
         accountHolder: "",
         iban: "",
@@ -259,6 +298,26 @@ export default {
         this.bookingStatus.isRejected !== true
       );
     },
+    showRefundPanel() {
+      return (
+        this.loadingRefundPreview ||
+        this.refundPreviewError ||
+        (this.refundPreview &&
+          Number(this.refundPreview.originalAmountEur) > 0)
+      );
+    },
+    refundPolicySummary() {
+      if (!this.refundPreview) return "";
+      const days =
+        this.refundPreview.daysBeforeStart === null ||
+        this.refundPreview.daysBeforeStart === undefined
+          ? "–"
+          : this.refundPreview.daysBeforeStart;
+      return this.$t("booking.cancellationRefund.userPolicySummary", {
+        days,
+        percentage: this.refundPreview.suggestedRefundPercentage,
+      });
+    },
     requiresBankDetails() {
       return !!(
         this.bookingStatus &&
@@ -270,23 +329,23 @@ export default {
     formattedPrice() {
       const price = this.bookingStatus && this.bookingStatus.priceEur;
       if (typeof price !== "number") return "";
-      try {
-        return new Intl.NumberFormat("de-DE", {
-          style: "currency",
-          currency: "EUR",
-        }).format(price);
-      } catch (e) {
-        return `${price.toFixed(2)} €`;
+      return FormatService.currency(price);
+    },
+    formattedExpectedRefund() {
+      if (
+        !this.refundPreview ||
+        typeof this.refundPreview.refundAmountEur !== "number"
+      ) {
+        return "";
       }
+      return FormatService.currency(this.refundPreview.refundAmountEur);
     },
     bankRules() {
       return {
         accountHolder: [],
         iban: [
           (v) =>
-            !v ||
-            isValidIban(v) ||
-            "Bitte geben Sie eine gültige IBAN an.",
+            !v || isValidIban(v) || "Bitte geben Sie eine gültige IBAN an.",
         ],
         bic: [
           (v) =>
@@ -298,6 +357,11 @@ export default {
     },
   },
   methods: {
+    onVerificationNameInput() {
+      this.refundPreview = null;
+      this.refundPreviewError = false;
+      this.showVerificationError = false;
+    },
     onIbanInput(value) {
       const normalized = normalizeIban(value);
       const formatted = normalized.replace(/(.{4})/g, "$1 ").trim();
@@ -321,6 +385,46 @@ export default {
       if (bankName) payload.bankName = bankName;
       return payload;
     },
+    async loadRefundPreview() {
+      const name = (this.verificationName || "").trim();
+      if (!name || !this.bookingNumber || !this.tenantId) {
+        return;
+      }
+
+      this.loadingRefundPreview = true;
+      this.refundPreviewError = false;
+      this.showVerificationError = false;
+
+      try {
+        const ownership = await ApiBookingService.verifyBookingOwnership(
+          this.tenantId,
+          this.bookingNumber,
+          name
+        );
+        if (ownership.status !== 200) {
+          this.refundPreview = null;
+          this.showVerificationError = true;
+          return;
+        }
+
+        this.refundPreview =
+          await ApiBookingService.getPublicCancellationRefundPreview(
+            this.bookingNumber,
+            this.tenantId,
+            name
+          );
+      } catch (error) {
+        const status = error && error.response && error.response.status;
+        this.refundPreview = null;
+        if (status === 401 || status === 403 || status === 404) {
+          this.showVerificationError = true;
+        } else {
+          this.refundPreviewError = true;
+        }
+      } finally {
+        this.loadingRefundPreview = false;
+      }
+    },
     async sendRejectRequest() {
       this.submitError = null;
       if (this.$refs.form && !this.$refs.form.validate()) {
@@ -339,6 +443,20 @@ export default {
           return;
         }
         this.showVerificationError = false;
+
+        if (!this.refundPreview) {
+          try {
+            this.refundPreview =
+              await ApiBookingService.getPublicCancellationRefundPreview(
+                this.bookingNumber,
+                this.tenantId,
+                this.verificationName
+              );
+          } catch (previewError) {
+            // Preview is informational; do not block cancellation request.
+            console.error(previewError);
+          }
+        }
 
         const bankDetailsPayload = this.buildBankDetailsPayload();
         const rejectResponse = await ApiBookingService.requestRejectBooking(
@@ -376,8 +494,9 @@ export default {
         );
         const data = bookingStatusResponse && bookingStatusResponse.data;
         const status = Array.isArray(data)
-          ? data.find((entry) => entry && entry.bookingId === this.bookingNumber) ||
-            data[0]
+          ? data.find(
+            (entry) => entry && entry.bookingId === this.bookingNumber
+          ) || data[0]
           : data;
         if (!status) {
           this.statusError = true;

--- a/src/views/VerifyRejectBooking.vue
+++ b/src/views/VerifyRejectBooking.vue
@@ -27,6 +27,15 @@
           Ihre Stornierung wurde erfolgreich bestätigt. Sie erhalten in Kürze
           eine Bestätigung per E-Mail.
         </p>
+        <CancellationRefundPanel
+          v-if="showRefundPanel"
+          class="text-left mt-4"
+          :title="$t('booking.cancellationRefund.expectedTitle')"
+          :original-amount-eur="refundPreview.originalAmountEur"
+          :refund-amount-eur="refundPreview.refundAmountEur"
+          :cancellation-fee-eur="refundPreview.cancellationFeeEur"
+          :policy-summary="refundPolicySummary"
+        />
       </v-card-text>
 
       <v-card-text class="text-center" v-else-if="rejectError">
@@ -55,7 +64,35 @@
           <strong>{{ bookingNumber }}</strong> wirklich stornieren?
         </p>
 
-        <div class="mt-4" style="display: flex; justify-content: center; gap: 8px">
+        <v-skeleton-loader
+          v-if="loadingRefundPreview"
+          type="list-item-three-line"
+          class="mt-4 mb-2"
+        />
+        <CancellationRefundPanel
+          v-else-if="showRefundPanel"
+          class="text-left mt-4"
+          :title="$t('booking.cancellationRefund.expectedTitle')"
+          :original-amount-eur="refundPreview.originalAmountEur"
+          :refund-amount-eur="refundPreview.refundAmountEur"
+          :cancellation-fee-eur="refundPreview.cancellationFeeEur"
+          :policy-summary="refundPolicySummary"
+          :footer="$t('booking.cancellationRefund.finalAmountHint')"
+        />
+        <v-alert
+          v-else-if="refundPreviewError"
+          type="warning"
+          text
+          dense
+          class="mt-4 mb-0 text-left"
+        >
+          {{ $t("booking.cancellationRefund.previewError") }}
+        </v-alert>
+
+        <div
+          class="mt-4"
+          style="display: flex; justify-content: center; gap: 8px"
+        >
           <v-btn
             color="primary"
             @click="releaseRejectHook"
@@ -71,9 +108,11 @@
 
 <script>
 import ApiBookingService from "@/services/api/ApiBookingService";
+import CancellationRefundPanel from "@/components/Booking/CancellationRefundPanel.vue";
 
 export default {
-  name: "RequestRejectBooking",
+  name: "VerifyRejectBooking",
+  components: { CancellationRefundPanel },
   props: {
     tenantId: {
       type: String,
@@ -86,9 +125,53 @@ export default {
       rejectSuccess: false,
       rejectError: false,
       fetching: false,
+      refundPreview: null,
+      loadingRefundPreview: false,
+      refundPreviewError: false,
     };
   },
+  computed: {
+    showRefundPanel() {
+      return (
+        this.refundPreview && Number(this.refundPreview.originalAmountEur) > 0
+      );
+    },
+    refundPolicySummary() {
+      if (!this.refundPreview) return "";
+      const days =
+        this.refundPreview.daysBeforeStart === null ||
+        this.refundPreview.daysBeforeStart === undefined
+          ? "–"
+          : this.refundPreview.daysBeforeStart;
+      return this.$t("booking.cancellationRefund.userPolicySummary", {
+        days,
+        percentage: this.refundPreview.suggestedRefundPercentage,
+      });
+    },
+  },
   methods: {
+    async loadRefundPreview() {
+      if (!this.bookingNumber || !this.tenantId || !this.hookId) {
+        return;
+      }
+
+      this.loadingRefundPreview = true;
+      this.refundPreviewError = false;
+      try {
+        this.refundPreview =
+          await ApiBookingService.getHookCancellationRefundPreview(
+            this.bookingNumber,
+            this.tenantId,
+            this.hookId
+          );
+      } catch (error) {
+        console.error(error);
+        this.refundPreview = null;
+        this.refundPreviewError = true;
+      } finally {
+        this.loadingRefundPreview = false;
+      }
+    },
     async releaseRejectHook() {
       this.fetching = true;
       this.rejectError = false;
@@ -113,7 +196,8 @@ export default {
       }
     },
   },
-  mounted() {
+  async mounted() {
+    await this.loadRefundPreview();
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- Add tenant cancellation refund-tier configuration in Admin UI
- Surface refund previews, persisted audit data, and shared refund amount UI for single and group booking cancel/reject flows
- Align cancellation PDF template editor and Handlebars variables with the new refund-tier fields

## Test plan
- [ ] Configure cancellation refund tiers on a tenant and save successfully
- [ ] Cancel/reject a single booking and verify refund preview + amounts
- [ ] Cancel/reject a group booking and verify the same refund UX
- [ ] Confirm persisted cancellation refund audit is shown on booking details
- [ ] Open cancellation PDF template editor and verify new variables/preview sample data
- [ ] Smoke-check German UI strings for the new refund/cancellation flows