### PR TITLE
fix: stop overwriting booking names on user update

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Fixed
 
 - Member and instance user search now uses case-insensitive substring matching on name and email instead of fuzzy matching, preventing unrelated results (DEV-784)
+- User create/update and profile update (`submitUser`, `updateMe`) now send `syncSelfBookingNames: false` so booking contact names are not overwritten
 
 
 ## [4.1.3] — 2026-07-03

--- a/src/services/api/ApiUsersService.js
+++ b/src/services/api/ApiUsersService.js
@@ -15,12 +15,18 @@ export default {
     return ApiClient.get(`api/users/${userId}`);
   },
   submitUser(user) {
-    return ApiClient.put("api/users", user);
+    return ApiClient.put("api/users", {
+      ...user,
+      syncSelfBookingNames: false,
+    });
   },
   deleteUser(user) {
     return ApiClient.delete(`api/users/${user.id}`);
   },
   updateMe(user) {
-    return ApiClient.put("api/user", user);
+    return ApiClient.put("api/user", {
+      ...user,
+      syncSelfBookingNames: false,
+    });
   },
 };


### PR DESCRIPTION
## Summary
- Send `syncSelfBookingNames: false` in the request body for `submitUser` and `updateMe`
- Prevents user/profile updates from overwriting booking contact names

## Test plan
- [ ] Edit a user in admin and save — request body includes `syncSelfBookingNames: false`
- [ ] Update own profile in Settings — request body includes `syncSelfBookingNames: false`
- [ ] Confirm booking contact names are not changed after a user/profile save