### PR TITLE
Allow multiple PUBLIC_ORIGIN values for BFF cookie auth

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -12,7 +12,9 @@ VUE_APP_SERVER_BASE_URL=http://localhost:8081
 # See docs/adr/0001-optional-admin-bff-shared-session.md
 # VUE_APP_AUTH_MODE=direct
 # VUE_APP_BFF_BASE_URL=/admin/api
+# Comma-separated browser origins (OIDC + CSRF). PUBLIC_ORIGINS is merged in (no override).
 # PUBLIC_ORIGIN=http://localhost:8080
+# PUBLIC_ORIGIN=https://booking.kunde.de,https://booking.system.example.com
 # Dev proxy target for the Admin BFF (must match bff PORT)
 # BFF_DEV_URL=http://localhost:3001
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ docker run -d \
 
 | Extra BFF env | Purpose |
 |---------------|---------|
-| `PUBLIC_ORIGIN` | Browser origin (OIDC redirect + CSRF Origin check) |
+| `PUBLIC_ORIGIN` / `PUBLIC_ORIGINS` | Comma-separated browser origin allowlist (OIDC redirect + CSRF); both merged |
 | `API_BASE_URL` | Backend for BFF (defaults to `VUE_APP_SERVER_BASE_URL`) |
 | `ADMIN_BFF_ENABLED=false` | Force Direct process layout even if you only want SPA flags differently |
 | `ADMIN_BFF_UPSTREAM` | Point nginx at an **external** BFF instead of the embedded one |

--- a/bff/.env-example
+++ b/bff/.env-example
@@ -6,12 +6,14 @@
 #   ADMIN_SPA_BASE_PATH ← BASE_URL
 #   COOKIE_SECURE     ← VUE_APP_IS_PRODUCTION (when COOKIE_SECURE unset)
 #   PUBLIC_ORIGIN     (same name in UI Docker / shared-session deploy)
+#   PUBLIC_ORIGINS    optional alias; merged with PUBLIC_ORIGIN (no override)
 #
 # Example root `.env` for local BFF mode:
 #   VUE_APP_AUTH_MODE=bff
 #   VUE_APP_SERVER_BASE_URL=http://localhost:8081
 #   VUE_APP_BFF_BASE_URL=/api
 #   PUBLIC_ORIGIN=http://localhost:8080
+#   # or multi-host: PUBLIC_ORIGIN=https://a.example.com,https://b.example.com
 #   BASE_URL=/admin   # optional; used for post-SSO SPA redirects in Docker
 
 # Listen port (BFF-only; no UI equivalent)

--- a/bff/README.md
+++ b/bff/README.md
@@ -67,7 +67,7 @@ Then point the UI container at it with:
 | `BFF_PUBLIC_PATH` | `VUE_APP_BFF_BASE_URL` | for SSO | Browser-facing BFF prefix (e.g. `/admin/api` or `/api`) |
 | `ADMIN_SPA_BASE_PATH` | `BASE_URL` | for SSO | SPA base for post-login redirects (`/admin` or empty) |
 | `COOKIE_SECURE` | `VUE_APP_IS_PRODUCTION` | no | Cookie `Secure` flag (else `NODE_ENV=production`) |
-| `PUBLIC_ORIGIN` | same | recommended in prod | Browser origin; CSRF Origin check + OIDC `redirect_uri` |
+| `PUBLIC_ORIGIN` / `PUBLIC_ORIGINS` | same | recommended in prod | Comma-separated browser origin allowlist; CSRF + OIDC. Both vars are **merged** (no override). Set-but-invalid → BFF refuses to start. |
 | `PORT` | — | no | Default `3001` |
 | `NODE_ENV` | — | no | `production` → secure cookies when no override |
 | `CORS_ORIGINS` | — | no | Comma-separated origins for credentialed CORS (dev) |
@@ -76,7 +76,8 @@ Then point the UI container at it with:
 
 - Session cookies: `access-token` and `refresh-token` are `HttpOnly` + `SameSite=lax` (+ `Secure` in production)
 - `auth-type` is readable (not HttpOnly) and may be omitted for local/card sessions — see `src/cookieContract.js`
-- When `PUBLIC_ORIGIN` is set, mutating requests with an `Origin`/`Referer` must match that origin (`src/csrf.js`)
+- When `PUBLIC_ORIGIN` / `PUBLIC_ORIGINS` is set, mutating requests with an `Origin`/`Referer` must match the **current** request origin (derived host must be allowlisted) (`src/csrf.js`)
+- OIDC `redirect_uri` is taken from the request host when allowlisted, stored in the PKCE session, and reused on callback (not re-derived from headers)
 - Details: [docs/bff-hardening.md](../docs/bff-hardening.md)
 
 ## Vue opt-in
@@ -90,6 +91,12 @@ VUE_APP_BFF_BASE_URL=/api
 PUBLIC_ORIGIN=http://localhost:8080
 ```
 
+Multiple public hostnames (custom domain + system default):
+
+```bash
+PUBLIC_ORIGIN=https://booking.kunde.de,https://booking.system.example.com
+```
+
 Then run the BFF (`npm run bff:dev` from repo root) and `npm run serve` — no separate `bff/.env` needed.
 
 ## Shared session with Storefront
@@ -98,15 +105,20 @@ When Admin (`/admin`) and Storefront (`/`) share one origin, both BFFs set the s
 
 ## Keycloak setup
 
-Register the BFF callback URL on the Keycloak public client, e.g.:
+Register the BFF callback URL on the Keycloak public client **for each** browser origin, e.g.:
 
 - Local: `http://localhost:8080/api/auth/sso/callback` (when `BFF_PUBLIC_PATH=/api`)
 - Shared origin: `https://example.com/admin/api/auth/sso/callback` (`BFF_PUBLIC_PATH=/admin/api`)
+- Multi-URL: one callback (+ web origin + post-logout redirect) per entry in `PUBLIC_ORIGIN`
 
 Set in the root `.env` (or BFF aliases):
 
 - `VUE_APP_BFF_BASE_URL` / `BFF_PUBLIC_PATH` — browser-facing BFF prefix
-- `PUBLIC_ORIGIN` — browser origin, e.g. `http://localhost:8080` (needed behind the vue-cli proxy so `redirect_uri` is not built with the BFF port)
+- `PUBLIC_ORIGIN` — comma-separated browser origins (needed behind the vue-cli proxy so `redirect_uri` is not built with the BFF port). Edge must forward `Host` / `X-Forwarded-Host` and `X-Forwarded-Proto`. Keep the BFF reachable only via the edge (not directly from the public internet).
+
+IDN custom domains: put env values consistently in Unicode **or** Punycode — mixing fails the allowlist match (`URL.origin` normalizes to Punycode).
+
+**Storefront note:** Admin multi-origin support does not automatically fix the Storefront BFF if it still uses a single `PUBLIC_ORIGIN`. Shared session on a second hostname needs a matching Storefront change (separate repo).
 
 PKCE state is kept in an in-memory store (plus cookies as fallback) so the Keycloak round-trip still works if the dev proxy drops `Set-Cookie` on 302 responses.
 

--- a/bff/src/config.js
+++ b/bff/src/config.js
@@ -94,8 +94,54 @@ const spaBasePath = stripTrailingSlash(
   firstEnv("ADMIN_SPA_BASE_PATH", "BASE_URL")
 );
 
-// Browser-facing origin for OIDC redirect_uri + CSRF checks
-const publicOrigin = stripTrailingSlash(firstEnv("PUBLIC_ORIGIN"));
+/**
+ * Parse PUBLIC_ORIGIN / PUBLIC_ORIGINS into a canonical allowlist.
+ * Both env vars are merged (no override). Empty / unset → no allowlist (dev).
+ * Set but zero valid entries → fail-closed startup error.
+ */
+function parsePublicOrigins() {
+  const rawParts = [];
+  for (const key of ["PUBLIC_ORIGIN", "PUBLIC_ORIGINS"]) {
+    const value = process.env[key];
+    if (value === undefined || value === null || String(value).trim() === "") {
+      continue;
+    }
+    for (const part of String(value).split(",")) {
+      const trimmed = part.trim();
+      if (trimmed) rawParts.push(trimmed);
+    }
+  }
+
+  if (rawParts.length === 0) {
+    return [];
+  }
+
+  const seen = new Set();
+  const origins = [];
+  for (const entry of rawParts) {
+    try {
+      const origin = new URL(entry).origin;
+      if (!seen.has(origin)) {
+        seen.add(origin);
+        origins.push(origin);
+      }
+    } catch {
+      console.warn(`PUBLIC_ORIGIN: skipping invalid entry (${entry})`);
+    }
+  }
+
+  if (origins.length === 0) {
+    console.error(
+      "PUBLIC_ORIGIN / PUBLIC_ORIGINS is set but no valid origins could be parsed"
+    );
+    process.exit(1);
+  }
+
+  return origins;
+}
+
+// Browser-facing origins for OIDC redirect_uri + CSRF (comma-separated allowlist)
+const publicOrigins = parsePublicOrigins();
 
 module.exports = {
   apiBaseUrl,
@@ -104,5 +150,5 @@ module.exports = {
   corsOrigins,
   bffPublicPath,
   spaBasePath,
-  publicOrigin,
+  publicOrigins,
 };

--- a/bff/src/cookies.js
+++ b/bff/src/cookies.js
@@ -15,6 +15,7 @@ const {
 const KC_CODE_VERIFIER = "kc-code-verifier";
 const KC_STATE = "kc-state";
 const KC_REDIRECT = "kc-redirect";
+const KC_REDIRECT_URI = "kc-redirect-uri";
 const KC_PENDING_TOKEN = "kc-pending-token";
 const KC_PENDING_REFRESH = "kc-pending-refresh";
 const KC_PENDING_REDIRECT = "kc-pending-redirect";
@@ -71,17 +72,21 @@ function clearAuthCookies(res) {
   res.clearCookie(AUTH_TYPE, clearOptions(false));
 }
 
-function setPkceCookies(res, { codeVerifier, state, redirect }) {
+function setPkceCookies(res, { codeVerifier, state, redirect, redirectUri }) {
   const opts = baseOptions(SHORT_MAX_AGE);
   res.cookie(KC_CODE_VERIFIER, codeVerifier, opts);
   res.cookie(KC_STATE, state, opts);
   res.cookie(KC_REDIRECT, redirect || "/", opts);
+  if (redirectUri) {
+    res.cookie(KC_REDIRECT_URI, redirectUri, opts);
+  }
 }
 
 function clearPkceCookies(res) {
   res.clearCookie(KC_CODE_VERIFIER, clearOptions(true));
   res.clearCookie(KC_STATE, clearOptions(true));
   res.clearCookie(KC_REDIRECT, clearOptions(true));
+  res.clearCookie(KC_REDIRECT_URI, clearOptions(true));
 }
 
 function setPendingSsoCookies(res, { accessToken, refreshToken, redirect }) {
@@ -120,6 +125,7 @@ function getPkceCookies(req) {
     codeVerifier: req.cookies?.[KC_CODE_VERIFIER] || null,
     state: req.cookies?.[KC_STATE] || null,
     redirect: req.cookies?.[KC_REDIRECT] || "/",
+    redirectUri: req.cookies?.[KC_REDIRECT_URI] || null,
   };
 }
 

--- a/bff/src/csrf.js
+++ b/bff/src/csrf.js
@@ -1,34 +1,35 @@
-const { publicOrigin } = require("./config");
+const { publicOrigins } = require("./config");
+const { getRequestOrigin } = require("./publicUrl");
 
 /**
  * Light CSRF guard for cookie-authenticated mutating requests.
  *
  * Primary protection remains SameSite=lax on auth cookies (browser will not
- * send them on cross-site POSTs). When PUBLIC_ORIGIN is set, also require
- * Origin/Referer to match that origin for non-GET requests that carry cookies.
+ * send them on cross-site POSTs). When PUBLIC_ORIGIN allowlist is set, also
+ * require Origin/Referer to match the *current* request origin (derived host
+ * must be allowlisted and equal the browser Origin).
  *
  * Requests without Origin/Referer (curl, health checks) are allowed so ops
  * tooling keeps working — classic browser CSRF always sends Origin on POST.
  */
 function createCsrfGuard() {
-  let allowedOrigin = null;
-  if (publicOrigin) {
-    try {
-      allowedOrigin = new URL(publicOrigin).origin;
-    } catch {
-      console.warn(
-        `CSRF: PUBLIC_ORIGIN is not a valid URL (${publicOrigin}) — Origin check disabled`
-      );
-    }
-  }
+  const allowlistActive = publicOrigins.length > 0;
 
   return function csrfGuard(req, res, next) {
     if (["GET", "HEAD", "OPTIONS"].includes(req.method)) {
       return next();
     }
 
-    if (!allowedOrigin) {
+    if (!allowlistActive) {
       return next();
+    }
+
+    const target = getRequestOrigin(req);
+    if (!target) {
+      return res.status(403).json({
+        success: false,
+        message: "CSRF check failed",
+      });
     }
 
     const originHeader = req.get("origin");
@@ -53,7 +54,7 @@ function createCsrfGuard() {
       });
     }
 
-    if (requestOrigin !== allowedOrigin) {
+    if (requestOrigin !== target) {
       return res.status(403).json({
         success: false,
         message: "CSRF check failed",

--- a/bff/src/index.js
+++ b/bff/src/index.js
@@ -26,7 +26,7 @@ app.get("/health", (_req, res) => {
   res.json({ ok: true, service: "admin-bff" });
 });
 
-// Cookie CSRF: SameSite=lax + optional Origin/Referer vs PUBLIC_ORIGIN
+// Cookie CSRF: SameSite=lax + optional Origin/Referer vs PUBLIC_ORIGIN allowlist
 app.use(createCsrfGuard());
 
 // JSON body only for BFF-owned auth routes (proxy streams its own body)

--- a/bff/src/pkceStore.js
+++ b/bff/src/pkceStore.js
@@ -17,12 +17,14 @@ function prune() {
   }
 }
 
-function savePkceSession(state, { codeVerifier, redirect, silent }) {
+function savePkceSession(state, { codeVerifier, redirect, silent, redirectUri }) {
   prune();
   store.set(String(state), {
     codeVerifier,
     redirect: redirect || "/",
     silent: !!silent,
+    // Must match authorize-time redirect_uri on token exchange (bit-identical)
+    redirectUri: redirectUri || null,
     expiresAt: Date.now() + TTL_MS,
   });
 }

--- a/bff/src/publicUrl.js
+++ b/bff/src/publicUrl.js
@@ -1,10 +1,10 @@
-const { bffPublicPath, spaBasePath, publicOrigin } = require("./config");
+const { bffPublicPath, spaBasePath, publicOrigins } = require("./config");
 
-function getRequestOrigin(req) {
-  if (publicOrigin) {
-    return publicOrigin;
-  }
-
+/**
+ * Derive browser origin from forwarded headers / Host.
+ * Always takes the first value of comma-separated X-Forwarded-* lists.
+ */
+function deriveOrigin(req) {
   const proto = (
     req.headers["x-forwarded-proto"] ||
     req.protocol ||
@@ -25,9 +25,55 @@ function getRequestOrigin(req) {
   return `${proto}://${host}`;
 }
 
+function isAllowedOrigin(origin) {
+  if (!origin) return false;
+  if (!publicOrigins.length) return true;
+  try {
+    return publicOrigins.includes(new URL(origin).origin);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Request origin for redirects / CSRF. Returns null when an allowlist is
+ * configured and the derived host is not on it (never falls back to the
+ * first allowlist entry).
+ */
+function getRequestOrigin(req) {
+  const derived = deriveOrigin(req);
+  if (!publicOrigins.length) {
+    return derived;
+  }
+  try {
+    const canonical = new URL(derived).origin;
+    return publicOrigins.includes(canonical) ? canonical : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Same as getRequestOrigin, but throws statusCode 400 when the host is not
+ * allowlisted (SSO start, logout redirect, absolute BFF URLs).
+ */
+function requireRequestOrigin(req) {
+  const origin = getRequestOrigin(req);
+  if (origin) {
+    return origin;
+  }
+  const derived = deriveOrigin(req);
+  const err = new Error(
+    `Request origin ${derived} is not in the PUBLIC_ORIGIN allowlist. ` +
+      "Check proxy headers (X-Forwarded-Host / X-Forwarded-Proto) and config."
+  );
+  err.statusCode = 400;
+  throw err;
+}
+
 /** External BFF base, e.g. http://localhost:8080/api */
 function getBffPublicBase(req) {
-  const origin = getRequestOrigin(req);
+  const origin = requireRequestOrigin(req);
   const prefix = bffPublicPath.replace(/\/$/, "");
   return `${origin}${prefix}`;
 }
@@ -46,7 +92,10 @@ function spaPath(pathname = "/") {
 }
 
 module.exports = {
+  deriveOrigin,
+  isAllowedOrigin,
   getRequestOrigin,
+  requireRequestOrigin,
   getBffPublicBase,
   getSsoCallbackUri,
   spaPath,

--- a/bff/src/publicUrl.js
+++ b/bff/src/publicUrl.js
@@ -36,21 +36,52 @@ function isAllowedOrigin(origin) {
 }
 
 /**
+ * Map a derived request origin onto the PUBLIC_ORIGIN allowlist.
+ * Exact match preferred; if only the scheme differs (common behind TLS
+ * termination where the app sees http), match hostname+port and return the
+ * allowlisted origin (correct public scheme).
+ */
+function resolveAllowlistedOrigin(derived) {
+  if (!publicOrigins.length) {
+    return derived;
+  }
+
+  let derivedUrl;
+  try {
+    derivedUrl = new URL(derived);
+  } catch {
+    return null;
+  }
+
+  const exact = derivedUrl.origin;
+  if (publicOrigins.includes(exact)) {
+    return exact;
+  }
+
+  for (const allowed of publicOrigins) {
+    try {
+      const allowedUrl = new URL(allowed);
+      if (
+        allowedUrl.hostname === derivedUrl.hostname &&
+        allowedUrl.port === derivedUrl.port
+      ) {
+        return allowedUrl.origin;
+      }
+    } catch {
+      // skip invalid allowlist entries (already filtered at startup)
+    }
+  }
+
+  return null;
+}
+
+/**
  * Request origin for redirects / CSRF. Returns null when an allowlist is
  * configured and the derived host is not on it (never falls back to the
  * first allowlist entry).
  */
 function getRequestOrigin(req) {
-  const derived = deriveOrigin(req);
-  if (!publicOrigins.length) {
-    return derived;
-  }
-  try {
-    const canonical = new URL(derived).origin;
-    return publicOrigins.includes(canonical) ? canonical : null;
-  } catch {
-    return null;
-  }
+  return resolveAllowlistedOrigin(deriveOrigin(req));
 }
 
 /**
@@ -94,6 +125,7 @@ function spaPath(pathname = "/") {
 module.exports = {
   deriveOrigin,
   isAllowedOrigin,
+  resolveAllowlistedOrigin,
   getRequestOrigin,
   requireRequestOrigin,
   getBffPublicBase,

--- a/bff/src/routes/auth.js
+++ b/bff/src/routes/auth.js
@@ -15,7 +15,7 @@ const {
   revokeKeycloakSession,
   buildBrowserLogoutUrl,
 } = require("../keycloak");
-const { getRequestOrigin, spaPath } = require("../publicUrl");
+const { requireRequestOrigin, spaPath } = require("../publicUrl");
 
 const router = express.Router();
 
@@ -200,7 +200,7 @@ router.post("/logout", async (req, res) => {
   if (wasKeycloak && browserLogout) {
     try {
       // Prefer registered URI without query (Keycloak post_logout_redirect_uri)
-      const postLogoutRedirectUri = `${getRequestOrigin(req)}${spaPath("/login")}`;
+      const postLogoutRedirectUri = `${requireRequestOrigin(req)}${spaPath("/login")}`;
       idpLogoutUrl = await buildBrowserLogoutUrl({
         postLogoutRedirectUri,
       });

--- a/bff/src/routes/sso.js
+++ b/bff/src/routes/sso.js
@@ -88,6 +88,7 @@ function resolvePkceSession(req, state) {
     return {
       codeVerifier: fromStore.codeVerifier,
       redirect: fromStore.redirect,
+      redirectUri: fromStore.redirectUri || null,
       state: String(state),
       silent: fromStore.silent,
     };
@@ -99,6 +100,7 @@ function resolvePkceSession(req, state) {
     return {
       codeVerifier: fromCookies.codeVerifier,
       redirect: fromCookies.redirect,
+      redirectUri: fromCookies.redirectUri || null,
       state: fromCookies.state,
       silent: String(fromCookies.state).startsWith("silent_"),
     };
@@ -115,11 +117,16 @@ router.get("/login", async (req, res) => {
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = generateCodeChallenge(codeVerifier);
     const state = generateState();
-
-    savePkceSession(state, { codeVerifier, redirect, silent: false });
-    setPkceCookies(res, { codeVerifier, state, redirect });
-
     const redirectUri = getSsoCallbackUri(req);
+
+    savePkceSession(state, {
+      codeVerifier,
+      redirect,
+      silent: false,
+      redirectUri,
+    });
+    setPkceCookies(res, { codeVerifier, state, redirect, redirectUri });
+
     console.log("SSO login start:", { redirectUri, state: state.slice(0, 8) });
 
     const authUrl = new URL(endpoints.authorization);
@@ -133,6 +140,10 @@ router.get("/login", async (req, res) => {
 
     return res.redirect(authUrl.toString());
   } catch (error) {
+    if (error.statusCode === 400) {
+      console.warn("SSO login rejected:", error.message);
+      return res.status(400).json({ success: false, message: error.message });
+    }
     console.error("SSO login error:", error);
     return res.redirect(spaPath("/login?error=sso_unavailable"));
   }
@@ -146,11 +157,16 @@ router.get("/silent-check", async (req, res) => {
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = generateCodeChallenge(codeVerifier);
     const state = generateState("silent_");
-
-    savePkceSession(state, { codeVerifier, redirect, silent: true });
-    setPkceCookies(res, { codeVerifier, state, redirect });
-
     const redirectUri = getSsoCallbackUri(req);
+
+    savePkceSession(state, {
+      codeVerifier,
+      redirect,
+      silent: true,
+      redirectUri,
+    });
+    setPkceCookies(res, { codeVerifier, state, redirect, redirectUri });
+
     const authUrl = new URL(endpoints.authorization);
     authUrl.searchParams.set("client_id", config.publicClient);
     authUrl.searchParams.set("response_type", "code");
@@ -162,7 +178,11 @@ router.get("/silent-check", async (req, res) => {
     authUrl.searchParams.set("prompt", "none");
 
     return res.redirect(authUrl.toString());
-  } catch {
+  } catch (error) {
+    if (error.statusCode === 400) {
+      console.warn("SSO silent-check rejected:", error.message);
+      return res.status(400).json({ success: false, message: error.message });
+    }
     return res.redirect(redirect);
   }
 });
@@ -197,7 +217,7 @@ router.get("/callback", async (req, res) => {
     return res.redirect(spaPath("/login?error=invalid_state"));
   }
 
-  if (!code || !pkce.codeVerifier) {
+  if (!code || !pkce.codeVerifier || !pkce.redirectUri) {
     if (isSilentCheck) return res.redirect(redirectPath);
     return res.redirect(spaPath("/login?error=missing_params"));
   }
@@ -205,7 +225,8 @@ router.get("/callback", async (req, res) => {
   try {
     const config = await getKeycloakConfig();
     const endpoints = getKeycloakEndpoints(config.serverUrl, config.realm);
-    const redirectUri = getSsoCallbackUri(req);
+    // Must be bit-identical to authorize-time redirect_uri (from PKCE state)
+    const redirectUri = pkce.redirectUri;
 
     const tokenResponse = await exchangeCodeForTokens({
       endpoints,

--- a/build_utils/docker-entrypoint.sh
+++ b/build_utils/docker-entrypoint.sh
@@ -53,6 +53,9 @@ start_embedded_bff() {
   echo "    BFF_PUBLIC_PATH=${BFF_PUBLIC_PATH}"
   echo "    ADMIN_BFF_UPSTREAM=${ADMIN_BFF_UPSTREAM}"
   echo "    PUBLIC_ORIGIN=${PUBLIC_ORIGIN:-"(unset)"}"
+  if [ -n "${PUBLIC_ORIGINS:-}" ]; then
+    echo "    PUBLIC_ORIGINS=${PUBLIC_ORIGINS}"
+  fi
 
   node /opt/admin-bff/src/index.js &
   BFF_PID=$!

--- a/build_utils/substitute_environment_variables.sh
+++ b/build_utils/substitute_environment_variables.sh
@@ -44,6 +44,8 @@ STRIP_PREFIX="${STRIP_PREFIX:-true}"
 ADMIN_BFF_UPSTREAM="${ADMIN_BFF_UPSTREAM:-}"
 ADMIN_BFF_LOCATION=""
 if [ -n "$ADMIN_BFF_UPSTREAM" ]; then
+  # Prefer edge X-Forwarded-* (Coolify/Traefik TLS termination) over nginx $scheme/$host
+  # which are http/internal when the container listens on :80 behind HTTPS.
   ADMIN_BFF_LOCATION=$(cat <<BFLEOF
     location = /admin/api {
       return 301 /admin/api/;
@@ -54,8 +56,8 @@ if [ -n "$ADMIN_BFF_UPSTREAM" ]; then
       proxy_set_header Host \$host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto \$scheme;
-      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Proto \$bff_forwarded_proto;
+      proxy_set_header X-Forwarded-Host \$bff_forwarded_host;
       proxy_set_header Cookie \$http_cookie;
       proxy_pass_header Set-Cookie;
     }
@@ -68,8 +70,8 @@ if [ -n "$ADMIN_BFF_UPSTREAM" ]; then
       proxy_set_header Host \$host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto \$scheme;
-      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Proto \$bff_forwarded_proto;
+      proxy_set_header X-Forwarded-Host \$bff_forwarded_host;
       proxy_set_header Cookie \$http_cookie;
       proxy_pass_header Set-Cookie;
     }
@@ -78,6 +80,19 @@ BFLEOF
   echo "==> Admin BFF proxy enabled → ${ADMIN_BFF_UPSTREAM}"
   echo "    nginx locations: /admin/api/ and /api/ (STRIP_PREFIX=${STRIP_PREFIX})"
 fi
+
+NGINX_FORWARDED_MAPS=$(cat <<'MAPSEOF'
+  # Preserve edge TLS / host when proxying to the embedded BFF (container is :80).
+  map $http_x_forwarded_proto $bff_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+  }
+  map $http_x_forwarded_host $bff_forwarded_host {
+    default $http_x_forwarded_host;
+    ""      $host;
+  }
+MAPSEOF
+)
 
 if [ "$LOCATION_PATH" = "/" ] || [ "$STRIP_PREFIX" = "true" ]; then
 
@@ -97,6 +112,7 @@ http {
   sendfile on;
   keepalive_timeout 65;
   add_header X-Frame-Options "DENY" always;
+${NGINX_FORWARDED_MAPS}
   server {
     listen 80;
     server_name localhost;
@@ -145,6 +161,7 @@ http {
   sendfile on;
   keepalive_timeout 65;
   add_header X-Frame-Options "DENY" always;
+${NGINX_FORWARDED_MAPS}
   server {
     listen 80;
     server_name localhost;

--- a/docker-compose.bff.example.yml
+++ b/docker-compose.bff.example.yml
@@ -29,6 +29,7 @@ services:
       VUE_APP_AUTH_MODE: bff
       VUE_APP_BFF_BASE_URL: /admin/api
       # PUBLIC_ORIGIN: https://example.com
+      # or: https://booking.kunde.de,https://booking.system.example.com
       # Optional BFF-only overrides (UI names above are enough):
       # API_BASE_URL / BFF_PUBLIC_PATH / ADMIN_SPA_BASE_PATH / COOKIE_SECURE
       # ADMIN_BFF_PORT: "3001"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- BFF CSRF behind TLS-terminating proxies (e.g. Coolify): map derived `http` host to allowlisted `https` origin by hostname; container nginx preserves edge `X-Forwarded-Proto` / `X-Forwarded-Host` when proxying to the embedded BFF
+
 ### Changed
 
 - BFF `PUBLIC_ORIGIN` accepts a comma-separated allowlist (optional `PUBLIC_ORIGINS` merged in): CSRF and OIDC redirects follow the request host when allowlisted; SSO callback reuses `redirect_uri` from the PKCE session. Set-but-invalid config fails closed at startup. **Note:** Storefront BFF may still need a matching multi-origin change for shared session on additional hostnames.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- BFF `PUBLIC_ORIGIN` accepts a comma-separated allowlist (optional `PUBLIC_ORIGINS` merged in): CSRF and OIDC redirects follow the request host when allowlisted; SSO callback reuses `redirect_uri` from the PKCE session. Set-but-invalid config fails closed at startup. **Note:** Storefront BFF may still need a matching multi-origin change for shared session on additional hostnames.
+
 ## [4.2.1] — 2026-07-22
 
 ### Added

--- a/docs/shared-session-deploy.md
+++ b/docs/shared-session-deploy.md
@@ -71,6 +71,8 @@ VUE_APP_AUTH_MODE=bff
 VUE_APP_BFF_BASE_URL=/admin/api
 VUE_APP_SERVER_BASE_URL=https://api.example.com
 PUBLIC_ORIGIN=https://example.com
+# Multiple hostnames (custom + system default), comma-separated; PUBLIC_ORIGINS is merged in:
+# PUBLIC_ORIGIN=https://booking.kunde.de,https://booking.system.example.com
 # BFF reads the same UI env names (no duplicate API_BASE_URL / BFF_PUBLIC_PATH needed).
 # Optional overrides only:
 # API_BASE_URL=https://api.example.com
@@ -83,14 +85,23 @@ PUBLIC_ORIGIN=https://example.com
 
 **Symptom of a broken BFF proxy:** `POST /api/auth/login` → `405`, or `GET /api/auth/me` returns HTML (`index.html`, ~1KB) with status 200. Then nginx is not forwarding to the BFF — check `STRIP_PREFIX` / edge strip vs. `VUE_APP_BFF_BASE_URL=/admin/api`.
 
+### Multi-URL / `PUBLIC_ORIGIN` allowlist
+
+- Comma-separated origins; `PUBLIC_ORIGIN` and `PUBLIC_ORIGINS` are **merged** (not overridden).
+- Request host (via `X-Forwarded-Host` / `Host` + `X-Forwarded-Proto`) must be on the allowlist; SSO `redirect_uri` follows that host and is stored in the PKCE session for the callback.
+- Edge must set `Host` / `X-Forwarded-Host` and `X-Forwarded-Proto` (see nginx sketch above). Expose the BFF **only** through the edge.
+- IDN: use Unicode **or** Punycode consistently in env values.
+- Sessions are **per hostname** (host-only cookies). No shared login across unrelated domains.
+- **Storefront:** if the Storefront BFF still has a single fixed `PUBLIC_ORIGIN`, shared session on additional hostnames needs a follow-up in that repo.
+
 ### Keycloak (BFF SSO)
 
-Valid redirect URIs must include:
+For **each** allowlisted origin, Valid redirect URIs must include:
 
-- `https://example.com/admin/api/auth/sso/callback`
-- Storefront callback (existing), e.g. `https://example.com/api/auth/sso/callback`
+- `{origin}/admin/api/auth/sso/callback` (Admin)
+- Storefront callback (existing), e.g. `{origin}/api/auth/sso/callback`
 
-Web origins: `https://example.com`.
+Also register matching Web origins and post-logout redirect URIs (`{origin}/admin/login`, …).
 
 ## Expected behaviour
 

--- a/docs/shared-session-deploy.md
+++ b/docs/shared-session-deploy.md
@@ -90,6 +90,7 @@ PUBLIC_ORIGIN=https://example.com
 - Comma-separated origins; `PUBLIC_ORIGIN` and `PUBLIC_ORIGINS` are **merged** (not overridden).
 - Request host (via `X-Forwarded-Host` / `Host` + `X-Forwarded-Proto`) must be on the allowlist; SSO `redirect_uri` follows that host and is stored in the PKCE session for the callback.
 - Edge must set `Host` / `X-Forwarded-Host` and `X-Forwarded-Proto` (see nginx sketch above). Expose the BFF **only** through the edge.
+- Behind TLS termination (Coolify/Traefik → container `:80`), the embedded nginx keeps edge `X-Forwarded-Proto`/`Host`. The BFF also maps an allowlisted hostname even if the derived scheme is still `http`.
 - IDN: use Unicode **or** Punycode consistently in env values.
 - Sessions are **per hostname** (host-only cookies). No shared login across unrelated domains.
 - **Storefront:** if the Storefront BFF still has a single fixed `PUBLIC_ORIGIN`, shared session on additional hostnames needs a follow-up in that repo.


### PR DESCRIPTION
## Summary
- `PUBLIC_ORIGIN` / `PUBLIC_ORIGINS` form a merged allowlist; OIDC redirects and CSRF use the current request host when allowlisted
- SSO callback reuses `redirect_uri` from the PKCE session (bit-identical token exchange); invalid allowlist config fails closed at startup
- Docs and deploy examples updated for multi-hostname setups (Keycloak per origin, edge `X-Forwarded-*`); Storefront multi-origin still a separate follow-up

## Test plan
- [ ] Local/password login works on two allowlisted origins (no CSRF 403)
- [ ] Full SSO roundtrip on origin B (start → Keycloak → callback → session)
- [ ] Logout on origin B builds a registered `post_logout_redirect_uri`
- [ ] Unknown host / missing `X-Forwarded-Host` → SSO start `400` with clear message
- [ ] `Origin: A` + `Host: B` (both allowlisted) → CSRF 403
- [ ] `PUBLIC_ORIGIN=not-a-url` → BFF refuses to start
- [ ] Single-value `PUBLIC_ORIGIN` still works (backcompat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple browser origins using comma-separated `PUBLIC_ORIGIN` and `PUBLIC_ORIGINS` values.
  * Origin-specific OIDC redirects and CSRF validation now support multi-host deployments.
  * SSO callbacks retain and validate the redirect URI used during login.

* **Bug Fixes**
  * Invalid origin configurations now prevent startup instead of weakening security checks.

* **Documentation**
  * Updated configuration, Docker, Keycloak, and shared-session guidance for multi-origin deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->