### PR TITLE
Improve tenant email settings UX and expert options.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Tenant email settings: choose booking-period date format in mails (`mailBookingPeriodFormat`) under Erweitert
+- Mail theme wizard: Arial as a selectable font family for email layouts
+
+### Changed
+
+- Support-footer toggle moved into the Erweitert panel together with the booking-period format option
+- Tenant email tab restructured into Versand, E-Mail-Layout, and E-Mail-Inhalte sections
+- Mail layout status: edit/create action separated from the status alert as a primary button
+
 ## [4.2.4] — 2026-07-29
 
 ### Fixed

--- a/src/components/Mail/BlockEditor/CombinedSnippetBlockEditor.vue
+++ b/src/components/Mail/BlockEditor/CombinedSnippetBlockEditor.vue
@@ -184,6 +184,7 @@ export default {
     variables: { type: Array, default: () => [] },
     snippetKey: { type: String, default: "" },
     showSupportFooter: { type: Boolean, default: true },
+    bookingPeriodFormat: { type: String, default: "default" },
   },
   data() {
     return {
@@ -200,6 +201,7 @@ export default {
       return (
         buildSnippetPreviewExtrasHtml(this.snippetKey, {
           showSupportFooter: this.showSupportFooter,
+          bookingPeriodFormat: this.bookingPeriodFormat,
         }) ||
         "<p style=\"margin:0;color:#666;\">Buchungsdetails und weitere System-Inhalte</p>"
       );

--- a/src/components/Mail/SnippetEditorDialog.vue
+++ b/src/components/Mail/SnippetEditorDialog.vue
@@ -138,6 +138,7 @@
                   :variables="variables"
                   :snippet-key="snippetKey"
                   :show-support-footer="showSupportFooter"
+                  :booking-period-format="bookingPeriodFormat"
                   @change="onCombinedChange"
                   @clear-after="clearAfter"
                 />
@@ -311,7 +312,7 @@ import {
   BOOKING_CANCEL_SNIPPET_VARIABLES,
   SAMPLE_DATA,
 } from "./templateVariables.js";
-import { buildSnippetPreviewExtrasHtml } from "./snippetPreviewExtras.js";
+import { buildSnippetPreviewExtrasHtml, sampleBookingPeriod } from "./snippetPreviewExtras.js";
 
 export default {
   name: "SnippetEditorDialog",
@@ -326,6 +327,7 @@ export default {
     layoutTemplate: { type: String, default: "" },
     tenantName: { type: String, default: "" },
     showSupportFooter: { type: Boolean, default: true },
+    bookingPeriodFormat: { type: String, default: "default" },
   },
   data() {
     return {
@@ -371,6 +373,7 @@ export default {
         tenantName:
           (this.tenantName && this.tenantName.trim()) || base.tenantName,
         currentDate: new Date().toLocaleDateString("de-DE"),
+        bookingPeriod: sampleBookingPeriod(this.bookingPeriodFormat),
       };
     },
     currentIntroSize() {
@@ -690,6 +693,7 @@ export default {
 
       const extrasHtml = buildSnippetPreviewExtrasHtml(this.snippetKey, {
         showSupportFooter: this.showSupportFooter,
+        bookingPeriodFormat: this.bookingPeriodFormat,
       });
       const renderedSnippetWithExtras =
         renderedIntro + (extrasHtml || "") + (renderedAfter || "");
@@ -769,6 +773,7 @@ export default {
         this.useLayoutInPreview,
         this.layoutTemplate,
         this.showSupportFooter,
+        this.bookingPeriodFormat,
       ],
       () => {
         if (this.activeTab === 1) {

--- a/src/components/Mail/SnippetList.vue
+++ b/src/components/Mail/SnippetList.vue
@@ -65,6 +65,7 @@
       :layout-template="layoutTemplate"
       :tenant-name="tenantName"
       :show-support-footer="showSupportFooter"
+      :booking-period-format="bookingPeriodFormat"
       @close="dialogOpen = false"
       @submit="onSubmit"
     />
@@ -89,6 +90,7 @@ export default {
     layoutTemplate: { type: String, default: "" },
     tenantName: { type: String, default: "" },
     showSupportFooter: { type: Boolean, default: true },
+    bookingPeriodFormat: { type: String, default: "default" },
   },
   data: () => ({
     catalog: SNIPPET_CATALOG,

--- a/src/components/Mail/ThemeWizard/themeDefaults.js
+++ b/src/components/Mail/ThemeWizard/themeDefaults.js
@@ -1,6 +1,7 @@
 export const FONT_FAMILY_MAP = {
   system:
     "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+  arial: "Arial, Helvetica, sans-serif",
   serif: "'Times New Roman', Georgia, serif",
   sans: "'Work Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif",
   mono: "'Courier New', Courier, monospace",
@@ -14,6 +15,7 @@ export const PRESETS = [
 
 export const FONT_OPTIONS = [
   { value: "system", text: "System (Standard)" },
+  { value: "arial", text: "Arial" },
   { value: "sans", text: "Sans Serif" },
   { value: "serif", text: "Serif" },
   { value: "mono", text: "Monospace" },

--- a/src/components/Mail/snippetPreviewExtras.js
+++ b/src/components/Mail/snippetPreviewExtras.js
@@ -6,12 +6,24 @@ const SAMPLE = {
   address: "Musterstraße 1, 12345 Musterstadt",
   phone: "0123 4567890",
   email: "max.mustermann@beispiel.de",
-  bookingPeriod: "21.05.2026, 10:00 – 21.05.2026, 12:00",
+  bookingPeriod: "09.07.2026, 05:15 - 09.07.2026, 08:00",
   itemTitle: "Tagungsraum Klein",
   itemAmount: "1",
   cancelReason: "Kunde hat Buchung widerrufen",
   rejectionReason: "Termin ist bereits vergeben",
 };
+
+const BOOKING_PERIOD_BY_FORMAT = {
+  default: "09.07.2026, 05:15 - 09.07.2026, 08:00",
+  fromTo: "von 05:15 Uhr am 09.07.2026 bis 08:00 Uhr am 09.07.2026",
+  timeFirst: "05:15 Uhr, 09.07.2026 - 08:00 Uhr, 09.07.2026",
+  long: "Donnerstag, 9. Juli 2026, 05:15 Uhr - Donnerstag, 9. Juli 2026, 08:00 Uhr",
+  compact: "09.07.26, 05:15 - 09.07.26, 08:00",
+};
+
+export function sampleBookingPeriod(format) {
+  return BOOKING_PERIOD_BY_FORMAT[format] || BOOKING_PERIOD_BY_FORMAT.default;
+}
 
 const STYLES = {
   section: "margin-top:16px; font-family:inherit; color:#222222; font-size:16px; line-height:1.5;",
@@ -68,7 +80,7 @@ function detailsBlock() {
   );
 }
 
-function contactBlock() {
+function contactBlock(bookingPeriod) {
   return (
     `<p style="${STYLES.contact}">` +
     `<strong>Firma:</strong> ${SAMPLE.company}<br />` +
@@ -76,7 +88,7 @@ function contactBlock() {
     `<strong>Adresse:</strong> ${SAMPLE.address}<br />` +
     `<strong>Telefon:</strong> ${SAMPLE.phone}<br />` +
     `<strong>E-Mail:</strong> <a href="mailto:${SAMPLE.email}" style="${STYLES.link}">${SAMPLE.email}</a><br />` +
-    `<strong>Buchungszeitraum:</strong> ${SAMPLE.bookingPeriod}` +
+    `<strong>Buchungszeitraum:</strong> ${bookingPeriod}` +
     "</p>"
   );
 }
@@ -124,11 +136,12 @@ export function buildSnippetPreviewExtrasHtml(key, options = {}) {
   if (!cfg) return "";
 
   const showSupportFooter = options.showSupportFooter !== false;
+  const bookingPeriod = sampleBookingPeriod(options.bookingPeriodFormat);
 
   const sections = [
     reasonBlock(cfg.reason),
     detailsBlock(),
-    contactBlock(),
+    contactBlock(bookingPeriod),
     orderOverview(),
     buttonsBlock({
       showPayment: !!cfg.showPayment,

--- a/src/components/Tenant/Edit/TenantEditEmail.vue
+++ b/src/components/Tenant/Edit/TenantEditEmail.vue
@@ -1,12 +1,12 @@
 <template>
   <v-form ref="form" v-model="valid">
     <BaseSection
-      title="E-Mail Konfiguration"
-      icon="mdi-email"
+      title="Versand"
+      icon="mdi-send"
       :hint="
         model.useInstanceMail
-          ? 'Es wird die Instanz-Konfiguration verwendet.'
-          : ''
+          ? 'Es wird die Instanz-Konfiguration für Absender und Versandmethode verwendet.'
+          : 'Absenderkonto und Versandmethode (SMTP oder Graph API).'
       "
     >
       <v-switch
@@ -19,7 +19,20 @@
         :mail-config="tenantMailConfig"
         :disabled="model.useInstanceMail"
         :show-validation="!model.useInstanceMail"
+        :show-template="false"
         @update="updateMailConfig"
+      />
+    </BaseSection>
+
+    <BaseSection
+      title="E-Mail-Layout"
+      icon="mdi-palette-outline"
+      hint="Äußeres Erscheinungsbild aller Mails (Logo, Farben, Header und Footer)."
+      class="mt-6"
+    >
+      <MailTemplateStatus
+        :mail-template="tenant.genericMailTemplate || ''"
+        @submit="onSubmitLayoutTemplate"
       />
     </BaseSection>
 
@@ -29,15 +42,6 @@
       hint="Pro Mail-Typ lassen sich Betreff, Einleitung (vor den Buchungsdetails) und optional ein Abschluss (nach Buttons, QR und System-Footer) anpassen. Strukturelle Bestandteile wie Buchungsdetails, Buttons und Footer werden automatisch ergänzt."
       class="mt-6"
     >
-      <v-switch
-        :input-value="mailShowSupportFooter"
-        color="primary"
-        class="mt-0 mb-4"
-        label="System-Footer mit Support-Kontakt anzeigen"
-        hint="Blendet den automatischen Hinweis „Falls Sie Fragen haben … kontaktieren“ ein oder aus. In eigenen Texten kannst du supportEmail weiterhin als Variable nutzen."
-        persistent-hint
-        @change="onSupportFooterChange"
-      />
       <SnippetList
         :mail-snippets="tenant.mailSnippets || {}"
         :mail-subjects="tenant.mailSubjects || {}"
@@ -45,8 +49,42 @@
         :layout-template="tenant.genericMailTemplate || ''"
         :tenant-name="tenant.name || ''"
         :show-support-footer="mailShowSupportFooter"
+        :booking-period-format="mailBookingPeriodFormat"
         @update="updateMailOverrides"
       />
+
+      <v-expansion-panels flat class="mt-4">
+        <v-expansion-panel>
+          <v-expansion-panel-header class="px-0 subtitle-2">
+            Erweitert
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-select
+              :value="mailBookingPeriodFormat"
+              :items="bookingPeriodFormatItems"
+              item-text="text"
+              item-value="value"
+              label="Datumsformat des Buchungszeitraums in E-Mails"
+              hint="Betrifft nur den automatisch erzeugten Zeitraum in den Buchungsdetails, nicht manuelle Snippet-Texte."
+              persistent-hint
+              dense
+              filled
+              background-color="accent"
+              class="mb-4"
+              @change="onBookingPeriodFormatChange"
+            />
+            <v-switch
+              :input-value="mailShowSupportFooter"
+              color="primary"
+              class="mt-0"
+              label="System-Footer mit Support-Kontakt anzeigen"
+              hint="Blendet den automatischen Hinweis „Falls Sie Fragen haben … kontaktieren“ ein oder aus. In eigenen Texten kannst du supportEmail weiterhin als Variable nutzen."
+              persistent-hint
+              @change="onSupportFooterChange"
+            />
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
     </BaseSection>
   </v-form>
 </template>
@@ -55,16 +93,52 @@
 import BaseSection from "@/components/commons/BaseSection.vue";
 import debounce from "lodash/debounce";
 import MailKonfiguration from "@/components/Tenant/MailKonfiguration.vue";
+import MailTemplateStatus from "@/components/Tenant/MailTemplateStatus.vue";
 import SnippetList from "@/components/Mail/SnippetList.vue";
 import ApiTenantService from "@/services/api/ApiTenantService";
 
+const BOOKING_PERIOD_FORMATS = [
+  "default",
+  "fromTo",
+  "timeFirst",
+  "long",
+  "compact",
+];
+
 export default {
   name: "TenantEditEmail",
-  components: { SnippetList, MailKonfiguration, BaseSection },
+  components: {
+    SnippetList,
+    MailKonfiguration,
+    MailTemplateStatus,
+    BaseSection,
+  },
   props: { tenant: Object },
   data: () => ({
     valid: false,
     defaultMailSnippets: {},
+    bookingPeriodFormatItems: [
+      {
+        value: "default",
+        text: "Standard — 09.07.2026, 05:15 - 09.07.2026, 08:00",
+      },
+      {
+        value: "fromTo",
+        text: "Von–bis — von 05:15 Uhr am 09.07.2026 bis 08:00 Uhr am 09.07.2026",
+      },
+      {
+        value: "timeFirst",
+        text: "Uhrzeit zuerst — 05:15 Uhr, 09.07.2026 - 08:00 Uhr, 09.07.2026",
+      },
+      {
+        value: "long",
+        text: "Lang — Donnerstag, 9. Juli 2026, 05:15 Uhr - …",
+      },
+      {
+        value: "compact",
+        text: "Kompakt — 09.07.26, 05:15 - 09.07.26, 08:00",
+      },
+    ],
   }),
   created() {
     this._emitDebounced = debounce((val) => {
@@ -84,7 +158,6 @@ export default {
     tenantMailConfig() {
       const t = this.tenant;
       return {
-        genericMailTemplate: t.genericMailTemplate,
         noreplyMail: t.noreplyMail,
         noreplyDisplayName: t.noreplyDisplayName,
         noreplyHost: t.noreplyHost,
@@ -101,6 +174,10 @@ export default {
     mailShowSupportFooter() {
       return this.tenant.mailShowSupportFooter !== false;
     },
+    mailBookingPeriodFormat() {
+      const value = this.tenant.mailBookingPeriodFormat;
+      return BOOKING_PERIOD_FORMATS.includes(value) ? value : "default";
+    },
   },
   methods: {
     async fetchDefaultMailTemplates() {
@@ -116,10 +193,24 @@ export default {
     updateMailConfig(cfg) {
       this.model = { ...this.tenant, ...cfg };
     },
+    onSubmitLayoutTemplate(newTemplate) {
+      this.model = {
+        ...this.tenant,
+        genericMailTemplate: newTemplate,
+      };
+    },
     onSupportFooterChange(value) {
       this.model = {
         ...this.tenant,
         mailShowSupportFooter: !!value,
+      };
+    },
+    onBookingPeriodFormatChange(value) {
+      this.model = {
+        ...this.tenant,
+        mailBookingPeriodFormat: BOOKING_PERIOD_FORMATS.includes(value)
+          ? value
+          : "default",
       };
     },
     updateMailOverrides({ mailSnippets, mailSubjects }) {

--- a/src/components/Tenant/MailKonfiguration.vue
+++ b/src/components/Tenant/MailKonfiguration.vue
@@ -1,39 +1,11 @@
 <template>
   <div>
-    <v-row>
-      <v-col class="">
-        <v-card
-          v-if="!!selectedMailConfig[templateField]"
-          color="success lighten-5"
-          class="rounded"
-        >
-          <v-card-text
-            class="success--text text--darken-1 d-flex justify-space-between align-center"
-          >
-            <div>
-              <v-icon left> mdi-check </v-icon>
-              Es ist eine E-Mail-Vorlage hinterlegt.
-            </div>
-
-            <v-btn small outlined @click="showEditTemplateDialog = true"
-              >bearbeiten</v-btn
-            >
-          </v-card-text>
-        </v-card>
-        <v-card v-else color="error lighten-5" class="rounded">
-          <v-card-text
-            class="error--text text--darken-1 d-flex justify-space-between align-center"
-          >
-            <div>
-              <v-icon left> mdi-check </v-icon>
-              Es ist keine E-Mail-Vorlage hinterlegt.
-            </div>
-
-            <v-btn small outlined @click="showEditTemplateDialog = true"
-              >bearbeiten</v-btn
-            >
-          </v-card-text>
-        </v-card>
+    <v-row v-if="showTemplate">
+      <v-col>
+        <MailTemplateStatus
+          :mail-template="selectedMailConfig[templateField]"
+          @submit="onSubmitTemplate"
+        />
       </v-col>
     </v-row>
 
@@ -45,6 +17,7 @@
           dense
           label="E-Mail-Adresse"
           :rules="showValidation ? validationRules.mail : []"
+          :disabled="disabled"
           v-model="selectedMailConfig.noreplyMail"
           @input="changeData"
         ></v-text-field>
@@ -55,6 +28,7 @@
           filled
           dense
           label="Anzeigename"
+          :disabled="disabled"
           v-model="selectedMailConfig.noreplyDisplayName"
           @input="changeData"
         ></v-text-field>
@@ -81,6 +55,7 @@
             hide-details
             :true-value="false"
             :false-value="true"
+            :disabled="disabled"
             label="SMTP als E-Mail-Versandmethode aktivieren"
             class="mt-2"
             @change="changeData"
@@ -94,6 +69,7 @@
             filled
             dense
             label="SMTP-Server"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyHost"
             @input="changeData"
           ></v-text-field>
@@ -104,6 +80,7 @@
             filled
             dense
             label="Port"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyPort"
             @input="changeData"
           ></v-text-field>
@@ -117,6 +94,7 @@
             dense
             hide-details
             label="Benutzername"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyUser"
             @input="changeData"
           ></v-text-field>
@@ -128,6 +106,7 @@
             dense
             hide-details
             label="Passwort"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyPassword"
             @input="changeData"
             :append-icon="showNoreplyPassword ? 'mdi-eye' : 'mdi-eye-off'"
@@ -144,6 +123,7 @@
             color="primary"
             label="StartTLS aktivieren"
             hide-details
+            :disabled="disabled"
           ></v-switch>
         </v-col>
       </v-row>
@@ -160,6 +140,7 @@
             v-model="selectedMailConfig.noreplyUseGraphApi"
             color="primary"
             hide-details
+            :disabled="disabled"
             label="Graph Api als E-Mail-Versandmethode aktivieren"
             class="mt-2"
             @change="changeData"
@@ -173,6 +154,7 @@
             filled
             dense
             label="Tenant ID"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyGraphTenantId"
             @input="changeData"
           ></v-text-field>
@@ -183,6 +165,7 @@
             filled
             dense
             label="Client ID"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyGraphClientId"
             @input="changeData"
           ></v-text-field>
@@ -195,6 +178,7 @@
             filled
             dense
             label="Client Secret"
+            :disabled="disabled"
             v-model="selectedMailConfig.noreplyGraphClientSecret"
             @input="changeData"
             :append-icon="showClientSecret ? 'mdi-eye' : 'mdi-eye-off'"
@@ -204,22 +188,16 @@
         </v-col>
       </v-row>
     </AppPanel>
-    <MailTemplateDialog
-      :open="showEditTemplateDialog"
-      :mail-template="selectedMailConfig[templateField]"
-      @submit="onSubmitTemplate"
-      @close="showEditTemplateDialog = false"
-    ></MailTemplateDialog>
   </div>
 </template>
 
 <script>
-import MailTemplateDialog from "@/components/Tenant/MailTemplateDialog.vue";
+import MailTemplateStatus from "@/components/Tenant/MailTemplateStatus.vue";
 import AppPanel from "@/components/AppPanel.vue";
 
 export default {
   name: "MailKonfiguration",
-  components: { MailTemplateDialog, AppPanel },
+  components: { MailTemplateStatus, AppPanel },
   props: {
     mailConfig: {
       type: Object,
@@ -228,6 +206,14 @@ export default {
     showValidation: {
       type: Boolean,
       default: true,
+    },
+    showTemplate: {
+      type: Boolean,
+      default: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
     templateField: {
       type: String,
@@ -239,7 +225,6 @@ export default {
     return {
       showNoreplyPassword: false,
       showClientSecret: false,
-      showEditTemplateDialog: false,
       validationRules: {
         mail: [
           (v) => !!v || "Pflichtfeld",
@@ -261,7 +246,6 @@ export default {
     },
     onSubmitTemplate(newTemplate) {
       this.$set(this.selectedMailConfig, this.templateField, newTemplate);
-      this.showEditTemplateDialog = false;
       this.changeData();
     },
   },

--- a/src/components/Tenant/MailTemplateStatus.vue
+++ b/src/components/Tenant/MailTemplateStatus.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <v-alert
+      :type="hasTemplate ? 'success' : 'warning'"
+      dense
+      text
+      class="mb-3"
+    >
+      {{
+        hasTemplate
+          ? "E-Mail-Vorlage ist hinterlegt."
+          : "Noch keine E-Mail-Vorlage hinterlegt."
+      }}
+    </v-alert>
+
+    <v-btn color="primary" @click="dialogOpen = true">
+      <v-icon left>mdi-pencil</v-icon>
+      {{ hasTemplate ? "Vorlage bearbeiten" : "Vorlage anlegen" }}
+    </v-btn>
+
+    <MailTemplateDialog
+      :open="dialogOpen"
+      :mail-template="mailTemplate"
+      @submit="onSubmit"
+      @close="dialogOpen = false"
+    />
+  </div>
+</template>
+
+<script>
+import MailTemplateDialog from "@/components/Tenant/MailTemplateDialog.vue";
+
+export default {
+  name: "MailTemplateStatus",
+  components: { MailTemplateDialog },
+  props: {
+    mailTemplate: { type: String, default: "" },
+  },
+  data: () => ({
+    dialogOpen: false,
+  }),
+  computed: {
+    hasTemplate() {
+      return !!(this.mailTemplate && String(this.mailTemplate).trim());
+    },
+  },
+  methods: {
+    onSubmit(newTemplate) {
+      this.dialogOpen = false;
+      this.$emit("submit", newTemplate);
+    },
+  },
+};
+</script>

--- a/src/entities/tenant.js
+++ b/src/entities/tenant.js
@@ -38,6 +38,7 @@ class Tenant {
     mailSnippets,
     mailSubjects,
     mailShowSupportFooter,
+    mailBookingPeriodFormat,
   }) {
     this.id = id;
     this.name = name;
@@ -78,6 +79,7 @@ class Tenant {
     this.mailSubjects = mailSubjects || {};
     this.mailShowSupportFooter =
       mailShowSupportFooter === undefined ? true : !!mailShowSupportFooter;
+    this.mailBookingPeriodFormat = mailBookingPeriodFormat || "default";
   }
 }
 


### PR DESCRIPTION
Restructure the email tab into Versand, Layout, and Inhalte; add booking-period format and Arial font; separate layout status from the edit action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable booking-period date and time formats for tenant emails and previews.
  * Added Arial as an available mail theme font.
  * Added create/edit controls and status feedback for generic mail templates.
  * Added advanced email settings for booking-period formatting and support-footer visibility.
  * Added disabled states for mail configuration fields when editing is unavailable.
* **Changed**
  * Restructured tenant email settings and separated template actions from status information.
  * Updated email previews to reflect the selected booking-period format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->