### PR TITLE
fix: clear bookable unsaved-changes chip after save

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bookable edit: unsaved-changes chip clears after a successful save (snapshot now matches the normalized bookable)
+
 ## [4.2.6] — 2026-08-10
 
 ### Changed

--- a/scripts/debug/bookable-unsaved-after-save.mjs
+++ b/scripts/debug/bookable-unsaved-after-save.mjs
@@ -1,0 +1,97 @@
+/**
+ * Feedback loop: after save, hasUnsavedChanges must be false.
+ *
+ * Mirrors BookableEdit.createOrUpdate + hasUnsavedChanges snapshot logic.
+ * Exit 1 = bug present (RED). Exit 0 = clean after save (GREEN).
+ *
+ * Usage: node scripts/debug/bookable-unsaved-after-save.mjs
+ */
+import _ from "lodash";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "../..");
+
+const { normalizeLeadTimeFields } = await import(
+  pathToFileURL(path.join(root, "src/utils/bookingLeadTime.js")).href
+);
+const { normalizeBookingDiscounts } = await import(
+  pathToFileURL(path.join(root, "src/utils/bookingDiscounts.js")).href
+);
+
+function sampleApiBookable(overrides = {}) {
+  return {
+    id: "b1",
+    tenantId: "t1",
+    title: "Test Room",
+    type: "room",
+    isScheduleRelated: true,
+    isTimePeriodRelated: false,
+    isBlockPeriodRelated: false,
+    freeBookingUsers: ["u1"],
+    freeBookingRoles: ["r1"],
+    customFields: [{ id: "cf1" }],
+    ...overrides,
+  };
+}
+
+function hasUnsavedChanges(bookable, originalSnapshot, isLoading = false) {
+  if (isLoading || !originalSnapshot || typeof originalSnapshot !== "string") {
+    return false;
+  }
+  const bookableClean = _.omit(bookable, ["customFields"]);
+  return (
+    JSON.stringify({
+      bookable: bookableClean,
+    }) !== originalSnapshot
+  );
+}
+
+/** Current createOrUpdate: snapshot from normalized bookable (same as init) */
+function applySave(responseData) {
+  const bookable = normalizeBookingDiscounts(
+    normalizeLeadTimeFields(_.cloneDeep(responseData))
+  );
+  const bookableClean = _.omit(bookable, ["customFields"]);
+  const originalSnapshot = JSON.stringify({
+    bookable: bookableClean,
+  });
+  return { bookable, originalSnapshot };
+}
+
+/** Legacy buggy path — kept to prove the harness still catches the regression */
+function applySaveBuggy(responseData) {
+  const bookable = normalizeBookingDiscounts(
+    normalizeLeadTimeFields(_.cloneDeep(responseData))
+  );
+  const bookableClean = _.omit(responseData, ["customFields"]);
+  const originalSnapshot = JSON.stringify({
+    bookable: bookableClean,
+  });
+  return { bookable, originalSnapshot };
+}
+
+const apiData = sampleApiBookable();
+
+{
+  const { bookable, originalSnapshot } = applySaveBuggy(apiData);
+  if (!hasUnsavedChanges(bookable, originalSnapshot)) {
+    console.error(
+      "Harness self-check failed: buggy path should stay dirty after save"
+    );
+    process.exit(2);
+  }
+}
+
+{
+  const { bookable, originalSnapshot } = applySave(apiData);
+  const dirty = hasUnsavedChanges(bookable, originalSnapshot);
+  console.log("after save hasUnsavedChanges:", dirty);
+  if (dirty) {
+    console.error("RED — unsaved-changes chip would stay visible after save");
+    process.exit(1);
+  }
+  console.log("GREEN — unsaved-changes cleared after save");
+  process.exit(0);
+}

--- a/src/components/Bookable/BookableEdit.vue
+++ b/src/components/Bookable/BookableEdit.vue
@@ -440,7 +440,8 @@ export default {
           });
         }
 
-        const bookableClean = _.omit(response.data, ["customFields"]);
+        // Match init(): snapshot the normalized bookable, not raw response.data
+        const bookableClean = _.omit(this.bookable, ["customFields"]);
 
         this.originalSnapshot = JSON.stringify({
           bookable: bookableClean,


### PR DESCRIPTION
Snapshot the normalized bookable after save (same as init) so lead-time and discount normalization no longer leaves the form marked dirty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Bookable edit unsaved-changes indicator so it clears after a successful save when no changes remain.
  * Improved save-state comparison by accounting for normalized Bookable data.

* **Documentation**
  * Added an unreleased changelog entry describing the fix.

* **Tests**
  * Added a standalone validation tool for checking Bookable save and unsaved-change behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->