### PR TITLE
Add showInMail switch for checkout custom fields in field dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Custom field dialog: "In Buchungs-E-Mails anzeigen" switch for checkout fields (`usageOptions.showInMail`) — value shows up in the booking-details block of all booking mails; reset when the field leaves the checkout context
+
 ### Fixed
 
 - BFF mode: Keycloak SSO login no longer fails with a gateway error — nginx proxy buffers raised so the callback's token cookies fit (`upstream sent too big header` → 502 on `/api/auth/sso/callback`)

--- a/src/components/CustomFields/CustomFieldDialog.vue
+++ b/src/components/CustomFields/CustomFieldDialog.vue
@@ -183,6 +183,15 @@
                 class="mt-0 pt-0"
                 dense
               />
+              <v-switch
+                v-model="local.usageOptions.showInMail"
+                label="In Buchungs-E-Mails anzeigen"
+                hint="Der im Buchungsprozess eingegebene Wert erscheint in den Buchungsdetails aller E-Mails zur Buchung — auch in denen an den Betreiber."
+                persistent-hint
+                color="primary"
+                class="mt-3 pt-0"
+                dense
+              />
             </v-card>
 
             <template v-if="local.usageOptions.context === 'catalog'">
@@ -317,6 +326,7 @@ const makeEmptyField = () => ({
   usageOptions: {
     context: "none",
     requiredInCheckout: false,
+    showInMail: false,
     filterable: false,
     catalogFilterType: null,
     catalogFilterPosition: "sidebar",
@@ -558,6 +568,7 @@ export default {
 
       if (v !== "checkout") {
         this.local.usageOptions.requiredInCheckout = false;
+        this.local.usageOptions.showInMail = false;
       }
       if (v !== "catalog") {
         this.local.usageOptions.filterable = false;
@@ -689,6 +700,10 @@ export default {
     normalizeUsageOptions(usageOptions) {
       const u = { ...usageOptions };
 
+      // Mirror of the server-side normalization: showInMail only exists on checkout fields
+      if (u.context !== "checkout") {
+        u.showInMail = false;
+      }
       if (u.context !== "catalog") {
         u.filterable = false;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting for checkout custom fields to control whether their values appear in booking details within booking emails.
  * The setting defaults to off and is automatically disabled when the field is no longer used during checkout.

* **Documentation**
  * Documented the new checkout email visibility setting in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->